### PR TITLE
Dev/cpa sync fix

### DIFF
--- a/smtp-listeners/src/main/kotlin/no/nav/emottak/HttpClients.kt
+++ b/smtp-listeners/src/main/kotlin/no/nav/emottak/HttpClients.kt
@@ -123,8 +123,7 @@ suspend fun HttpClient.getCPATimestamps() =
 suspend fun HttpClient.putCPAinCPARepo(cpaFile: String, lastModified: Instant) =
     this.post(URL_CPA_REPO_PUT) {
         headers {
-            header("updated_date", lastModified.toString())
-            header("upsert", "true") // Upsert kan nok alltid brukes (?)
+            header("updated_date", lastModified)
         }
         setBody(cpaFile)
     }

--- a/smtp-listeners/src/main/kotlin/no/nav/emottak/HttpClients.kt
+++ b/smtp-listeners/src/main/kotlin/no/nav/emottak/HttpClients.kt
@@ -33,7 +33,6 @@ import no.nav.emottak.smtp.log
 import java.net.InetSocketAddress
 import java.net.Proxy
 import java.net.URL
-import java.time.Instant
 
 val URL_CPA_REPO_BASE = getEnvVar("URL_CPA_REPO", "http://cpa-repo.team-emottak.svc.nais.local")
 val URL_CPA_REPO_PUT = "$URL_CPA_REPO_BASE/cpa".also { log.info("CPA REPO PUT URL: [$it]") }
@@ -120,7 +119,7 @@ suspend fun HttpClient.getCPATimestamps() =
         this.get(URL_CPA_REPO_TIMESTAMPS).bodyAsText()
     )
 
-suspend fun HttpClient.putCPAinCPARepo(cpaFile: String, lastModified: Instant) =
+suspend fun HttpClient.putCPAinCPARepo(cpaFile: String, lastModified: String) =
     this.post(URL_CPA_REPO_PUT) {
         headers {
             header("updated_date", lastModified)

--- a/smtp-listeners/src/main/kotlin/no/nav/emottak/smtp/cpasync/CpaSyncService.kt
+++ b/smtp-listeners/src/main/kotlin/no/nav/emottak/smtp/cpasync/CpaSyncService.kt
@@ -12,100 +12,93 @@ import org.slf4j.LoggerFactory
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 
-class CpaSyncService(private val cpaRepoClient: HttpClient, private val nfsConnector: NFSConnector) {
+data class NfsCpa(val id: String, val timestamp: String, val content: String)
 
+class CpaSyncService(private val cpaRepoClient: HttpClient, private val nfsConnector: NFSConnector) {
     private val log: Logger = LoggerFactory.getLogger("no.nav.emottak.smtp.cpasync")
 
     suspend fun sync() {
         return runCatching {
-            val cpaTimestamps = cpaRepoClient.getCPATimestamps()
-            processAndSyncEntries(cpaTimestamps)
+            val dbCpaMap = cpaRepoClient.getCPATimestamps()
+            val nfsCpaMap = getNfsCpaMap()
+            upsertFreshCpa(nfsCpaMap, dbCpaMap)
+            deleteStaleCpa(nfsCpaMap.keys, dbCpaMap)
         }.onFailure {
             logFailure(it)
         }.getOrThrow()
     }
 
-    private suspend fun processAndSyncEntries(cpaTimestamps: Map<String, String>) {
-        nfsConnector.use { connector ->
-            val staleCpaTimestamps = connector.folder().asSequence()
+    internal fun getNfsCpaMap(): Map<String, NfsCpa> {
+        return nfsConnector.use { connector ->
+            connector.folder().asSequence()
                 .filter { entry -> isXmlFileEntry(entry) }
-                .fold(cpaTimestamps) { accumulatedCpaTimestamps, entry ->
-                    val filename = entry.filename
-                    val lastModified = getLastModifiedInstant(entry.attrs.mTime.toLong())
-                    val shouldSkip = shouldSkipFile(filename, lastModified, accumulatedCpaTimestamps)
-                    if (!shouldSkip) {
-                        runCatching {
-                            log.info("Fetching file $filename")
-                            val cpaFileContent = connector.file("/outbound/cpa/$filename").use {
-                                String(it.readAllBytes())
-                            }
-                            log.info("Uploading $filename")
-                            cpaRepoClient.putCPAinCPARepo(cpaFileContent, lastModified)
-                        }.onFailure {
-                            log.error("Error uploading $filename to cpa-repo: ${it.message}", it)
-                        }
-                    }
+                .fold(mutableMapOf()) { accumulator, nfsCpaFile ->
+                    val nfsCpa = getNfsCpa(connector, nfsCpaFile)
 
-                    filterStaleCpaTimestamps(filename, lastModified, accumulatedCpaTimestamps)
+                    val existingEntry = accumulator.put(nfsCpa.id, nfsCpa)
+                    require(existingEntry == null) { "NFS contains duplicate CPA IDs. Aborting sync." }
+
+                    accumulator
                 }
-
-            deleteStaleCpaEntries(staleCpaTimestamps)
         }
     }
 
-    internal fun getLastModifiedInstant(mTimeInSeconds: Long): Instant {
-        return Instant.ofEpochSecond(mTimeInSeconds).truncatedTo(ChronoUnit.SECONDS)
+    internal fun isXmlFileEntry(entry: ChannelSftp.LsEntry): Boolean {
+        if (entry.filename.endsWith(".xml")) {
+            return true
+        }
+        log.warn("${entry.filename} is ignored. Invalid file ending")
+        return false
     }
 
-    private fun isXmlFileEntry(entry: ChannelSftp.LsEntry) = if (!entry.filename.endsWith(".xml")) {
-        log.warn("${entry.filename} is ignored")
-        false
-    } else {
-        true
+    internal fun getNfsCpa(connector: NFSConnector, nfsCpaFile: ChannelSftp.LsEntry): NfsCpa {
+        val timestamp = getLastModified(nfsCpaFile.attrs.mTime.toLong())
+        val cpaContent = fetchNfsCpaContent(connector, nfsCpaFile)
+        val cpaId = getCpaIdFromCpaContent(cpaContent)
+        require(cpaId != null) {
+            "Regex to find CPA ID in file ${nfsCpaFile.filename} did not find any match. " +
+                "File corrupted or wrongful regex. Aborting sync."
+        }
+
+        return NfsCpa(cpaId, timestamp, cpaContent)
     }
 
-    private fun filterStaleCpaTimestamps(
-        filename: String,
-        lastModified: Instant,
-        cpaTimestamps: Map<String, String>
-    ): Map<String, String> {
-        return cpaTimestamps.filter { (cpaId, timestamp) -> isStaleCpa(cpaId, filename, timestamp, lastModified) }
+    private fun fetchNfsCpaContent(nfsConnector: NFSConnector, nfsCpaFile: ChannelSftp.LsEntry): String {
+        return nfsConnector.file("/outbound/cpa/${nfsCpaFile.filename}").use {
+            String(it.readAllBytes())
+        }
     }
 
-    private fun isStaleCpa(
-        cpaId: String,
-        filename: String,
-        timestamp: String,
-        lastModified: Instant
-    ): Boolean {
-        val formattedCpaId = cpaId.replace(":", ".") + ".xml"
-        return if (filename == formattedCpaId) {
-            if (timestamp != lastModified.toString()) {
-                log.info("$filename has different timestamp, should be updated")
+    private fun getCpaIdFromCpaContent(cpaContent: String): String? {
+        return Regex("cppa:cpaid=\"(?<cpaId>.+?)\"")
+            .find(cpaContent)?.groups?.get("cpaId")?.value
+    }
+
+    internal fun getLastModified(mTimeInSeconds: Long): String {
+        return Instant.ofEpochSecond(mTimeInSeconds).truncatedTo(ChronoUnit.SECONDS).toString()
+    }
+
+    private suspend fun upsertFreshCpa(nfsCpaMap: Map<String, NfsCpa>, dbCpaMap: Map<String, String>) {
+        nfsCpaMap.forEach { entry ->
+            if (shouldUpsertCpa(entry.value.timestamp, dbCpaMap[entry.key])) {
+                log.info("Upserting new/modified CPA: ${entry.key} - ${entry.value.timestamp}")
+                cpaRepoClient.putCPAinCPARepo(entry.value.content, entry.value.timestamp)
+            } else {
+                log.info("Skipping upsert for unmodified CPA: ${entry.key} - ${entry.value.timestamp}")
             }
-            false
-        } else {
-            true // the file will be deleted
         }
     }
 
-    internal fun shouldSkipFile(
-        filename: String,
-        lastModified: Instant,
-        cpaTimestamps: Map<String, String>
-    ): Boolean {
-        return cpaTimestamps
-            .filterKeys { cpaId -> filename == cpaId.replace(":", ".") + ".xml" }
-            .filterValues { timestamp -> lastModified.toString() == timestamp }
-            .ifEmpty {
-                log.info("Could not find matching timestamp for file $filename with lastModified timestamp $lastModified")
-                return false
-            }.any()
+    internal fun shouldUpsertCpa(nfsTimestamp: String, dbTimestamp: String?): Boolean {
+        if (dbTimestamp == null) return true
+        return Instant.parse(nfsTimestamp) > Instant.parse(dbTimestamp)
     }
 
-    internal suspend fun deleteStaleCpaEntries(cpaTimestamps: Map<String, String>) {
-        cpaTimestamps.forEach { (cpaId) ->
-            cpaRepoClient.deleteCPAinCPARepo(cpaId)
+    private suspend fun deleteStaleCpa(nfsCpaIds: Set<String>, dbCpaMap: Map<String, String>) {
+        val staleCpa = dbCpaMap - nfsCpaIds
+        staleCpa.forEach { entry ->
+            log.info("Deleting stale entry: ${entry.key} - ${entry.value}")
+            cpaRepoClient.deleteCPAinCPARepo(entry.key)
         }
     }
 

--- a/smtp-listeners/src/test/kotlin/no/nav/emottak/smtp/cpasync/CpaSyncServiceTest.kt
+++ b/smtp-listeners/src/test/kotlin/no/nav/emottak/smtp/cpasync/CpaSyncServiceTest.kt
@@ -20,241 +20,294 @@ import no.nav.emottak.deleteCPAinCPARepo
 import no.nav.emottak.getCPATimestamps
 import no.nav.emottak.nfs.NFSConnector
 import no.nav.emottak.putCPAinCPARepo
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import java.io.ByteArrayInputStream
+import java.io.File
 import java.time.Instant
 import java.util.*
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
-import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class CpaSyncServiceTest {
-
-    private val cpaRepoClient: HttpClient = mockk(relaxed = true)
+    private val mockCpaRepoClient: HttpClient = mockk(relaxed = true)
     private val mockHttpResponse: HttpResponse = mockk(relaxed = true)
-    private lateinit var cpaSyncService: CpaSyncService
+    private val mockNFSConnector: NFSConnector = mockk(relaxed = true)
 
     @BeforeEach
     fun setUp() {
         mockkStatic("no.nav.emottak.HttpClientsKt")
-        clearMocks(cpaRepoClient)
-        coEvery { cpaRepoClient.deleteCPAinCPARepo(any()) } returns mockHttpResponse
-        coEvery { cpaRepoClient.putCPAinCPARepo(any(), any()) } returns mockHttpResponse
+        clearMocks(mockCpaRepoClient)
+        coEvery { mockCpaRepoClient.deleteCPAinCPARepo(any()) } returns mockHttpResponse
+        coEvery { mockCpaRepoClient.putCPAinCPARepo(any(), any()) } returns mockHttpResponse
     }
 
     @Test
-    fun `sync should do nothing when all entries match own database`() = runBlocking {
-        val cpaTimestampsFromDb = mutableMapOf("cpa1" to "2024-01-01T00:00:00Z", "cpa2" to "2024-01-01T00:00:00Z")
-        val mockedAttrs = mockSftpAttrs(1704067200)
-        val entries = listOf(
-            mockLsEntry("cpa1.xml", mockedAttrs),
-            mockLsEntry("cpa2.xml", mockedAttrs)
+    fun `should return true for XML file`() {
+        val lsEntry = mockLsEntry("nav.qass.12345.xml", "2024-01-01T00:00:00Z")
+        val cpaSyncService = CpaSyncService(mockCpaRepoClient, mockNFSConnector)
+
+        assertTrue(cpaSyncService.isXmlFileEntry(lsEntry))
+    }
+
+    @Test
+    fun `should return false for invalid file type`() {
+        val lsEntry = mockLsEntry("nav.qass.12345.txt", "2024-01-01T00:00:00Z")
+        val cpaSyncService = CpaSyncService(mockCpaRepoClient, mockNFSConnector)
+
+        assertFalse(cpaSyncService.isXmlFileEntry(lsEntry))
+    }
+
+    @Test
+    fun `should not send request if invalid file type`() = runBlocking {
+        val lsEntry = mockLsEntry("nav.qass.12345.txt", "2025-01-01T00:00:00Z")
+        val mockNfs = mockNfsFromEntries(listOf(lsEntry), listOf("nav:qass:12345"))
+
+        mockCpaRepoFromMap(emptyMap())
+
+        val cpaSyncService = CpaSyncService(mockCpaRepoClient, mockNfs)
+        cpaSyncService.sync()
+
+        coVerify(exactly = 0) { mockCpaRepoClient.putCPAinCPARepo(any(), any()) }
+        coVerify(exactly = 0) { mockCpaRepoClient.deleteCPAinCPARepo(any()) }
+    }
+
+    @Test
+    fun `should get cpaId from xml content`() = runBlocking {
+        val lsEntry = mockLsEntry("nav.qass.12345.xml", "2025-01-01T00:00:00Z")
+        val mockNfs = mockNfsFromEntries(listOf(lsEntry), listOf("nav:qass:12345"))
+
+        val cpaSyncService = CpaSyncService(mockCpaRepoClient, mockNfs)
+        val nfsCpa = cpaSyncService.getNfsCpa(mockNfs, lsEntry)
+
+        assertEquals("nav:qass:12345", nfsCpa.id)
+    }
+
+    @Test
+    fun `should find cpaId from an actual CPA file`() = runBlocking {
+        val lsEntry = mockLsEntry("nav.qass.12345.txt", "2025-01-01T00:00:00Z")
+        val mockNfs: NFSConnector = mockk {
+            every { folder() } returns Vector<ChannelSftp.LsEntry>().apply { add(lsEntry) }
+            every { file(any()) } returns File(ClassLoader.getSystemResource("cpa/nav.qass.12345.xml").file).inputStream()
+            every { close() } just Runs
+        }
+
+        val cpaSyncService = CpaSyncService(mockCpaRepoClient, mockNfs)
+        val nfsCpa = cpaSyncService.getNfsCpa(mockNfs, lsEntry)
+
+        assertEquals("nav:qass:12345", nfsCpa.id)
+    }
+
+    @Test
+    fun `should throw exception if CPA ID is missing in content`() = runBlocking {
+        val lsEntry = mockLsEntry("nav.qass.missing.txt", "2025-01-01T00:00:00Z")
+        val mockNfs = mockNfsFromEntries(listOf(lsEntry), listOf(""))
+
+        val cpaSyncService = CpaSyncService(mockCpaRepoClient, mockNfs)
+
+        val exception = assertThrows<IllegalArgumentException> {
+            cpaSyncService.getNfsCpa(mockNfs, lsEntry)
+        }
+
+        assertTrue(exception.message!!.contains("Regex to find CPA ID in file nav.qass.missing.txt did not find any match."))
+    }
+
+    @Test
+    fun `nfs mTime conversion to db timestamp should be accurate`() {
+        val mTimeInSeconds = 1704067200L
+        val expectedTimestamp = "2024-01-01T00:00:00Z"
+
+        val cpaSyncService = CpaSyncService(mockCpaRepoClient, mockNFSConnector)
+
+        val actualTimestamp = cpaSyncService.getLastModified(mTimeInSeconds)
+
+        assert(expectedTimestamp == actualTimestamp)
+    }
+
+    @Test
+    fun `sync should abort if duplicate cpa IDs is found in nfs`() = runBlocking {
+        val lsEntries = listOf(
+            mockLsEntry("nav.qass.12345.xml", "2025-01-01T00:00:00Z"),
+            mockLsEntry("nav.qass.12345.xml", "2025-01-01T00:00:00Z")
         )
-        val mockedNFSConnector = mockNFSConnector(entries)
-        cpaSyncService = CpaSyncService(cpaRepoClient, mockedNFSConnector)
+        val mockNfs = mockNfsFromEntries(lsEntries, listOf("nav:qass:12345", "nav:qass:12345"))
 
-        coEvery { cpaRepoClient.getCPATimestamps() } returns cpaTimestampsFromDb
+        val cpaSyncService = CpaSyncService(mockCpaRepoClient, mockNfs)
 
-        cpaSyncService.sync()
+        val exception = assertThrows<IllegalArgumentException> {
+            cpaSyncService.getNfsCpaMap()
+        }
 
-        coVerify(exactly = 0) { cpaRepoClient.putCPAinCPARepo(any(), any()) }
-        coVerify(exactly = 0) { cpaRepoClient.deleteCPAinCPARepo(any()) }
+        assertTrue(exception.message!!.contains("NFS contains duplicate CPA IDs. Aborting sync."))
     }
 
     @Test
-    fun `sync should delete entry cpa2 from own database after it is gone from files`() = runBlocking {
-        val cpaTimestampsFromDb = mutableMapOf("cpa1" to "2024-01-01T00:00:00Z", "cpa2" to "2024-01-01T00:00:00Z")
-        val mockedAttrs = mockSftpAttrs(1704067200)
-        val entries = listOf(mockLsEntry("cpa1.xml", mockedAttrs))
-        val mockedNFSConnector = mockNFSConnector(entries)
-        cpaSyncService = CpaSyncService(cpaRepoClient, mockedNFSConnector)
+    fun `sync should do nothing when all entries match database`() = runBlocking {
+        val nfsCpa = mapOf("nav:qass:12345" to "2024-01-01T00:00:00Z")
+        val dbCpa = mapOf("nav:qass:12345" to "2024-01-01T00:00:00Z")
 
-        coEvery { cpaRepoClient.getCPATimestamps() } returns cpaTimestampsFromDb
+        val mockNfs = mockNfsFromMap(nfsCpa)
+        mockCpaRepoFromMap(dbCpa)
 
+        val cpaSyncService = CpaSyncService(mockCpaRepoClient, mockNfs)
         cpaSyncService.sync()
 
-        coVerify(exactly = 0) { cpaRepoClient.putCPAinCPARepo(any(), any()) }
-        coVerify(exactly = 1) { cpaRepoClient.deleteCPAinCPARepo("cpa2") }
+        coVerify(exactly = 0) { mockCpaRepoClient.putCPAinCPARepo(any(), any()) }
+        coVerify(exactly = 0) { mockCpaRepoClient.deleteCPAinCPARepo(any()) }
     }
 
     @Test
-    fun `sync should insert new entry into our database after receiving it from files`() = runBlocking {
-        val cpaTimestampsFromDb = mutableMapOf("cpa1" to "2024-01-01T00:00:00Z")
-        val mockedAttrs = mockSftpAttrs(1704067200)
-        val entries = listOf(
-            mockLsEntry("cpa1.xml", mockedAttrs),
-            mockLsEntry("cpa2.xml", mockedAttrs)
+    fun `sync should ignore entries when db timestamp is newer`() = runBlocking {
+        val nfsCpa = mapOf("nav:qass:12345" to "2024-01-01T00:00:00Z")
+        val dbCpa = mapOf("nav:qass:12345" to "2025-01-01T00:00:00Z")
+
+        val mockNfs = mockNfsFromMap(nfsCpa)
+        mockCpaRepoFromMap(dbCpa)
+
+        val cpaSyncService = CpaSyncService(mockCpaRepoClient, mockNfs)
+        cpaSyncService.sync()
+
+        coVerify(exactly = 0) { mockCpaRepoClient.putCPAinCPARepo(any(), any()) }
+        coVerify(exactly = 0) { mockCpaRepoClient.deleteCPAinCPARepo(any()) }
+    }
+
+    @Test
+    fun `sync should upsert when nfs timestamp is newer`() = runBlocking {
+        val nfsCpa = mapOf("nav:qass:12345" to "2025-01-01T00:00:00Z")
+        val dbCpa = mapOf("nav:qass:12345" to "2024-01-01T00:00:00Z")
+
+        val mockNfs = mockNfsFromMap(nfsCpa)
+        mockCpaRepoFromMap(dbCpa)
+
+        val cpaSyncService = CpaSyncService(mockCpaRepoClient, mockNfs)
+        cpaSyncService.sync()
+
+        coVerify(exactly = 1) { mockCpaRepoClient.putCPAinCPARepo(any(), any()) }
+    }
+
+    @Test
+    fun `sync should upsert when entry does not exist in db`() = runBlocking {
+        val nfsCpa = mapOf("nav:qass:12345" to "2024-01-01T00:00:00Z")
+        val dbCpa = emptyMap<String, String>()
+
+        val mockNfs = mockNfsFromMap(nfsCpa)
+        mockCpaRepoFromMap(dbCpa)
+
+        val cpaSyncService = CpaSyncService(mockCpaRepoClient, mockNfs)
+        cpaSyncService.sync()
+
+        coVerify(exactly = 1) { mockCpaRepoClient.putCPAinCPARepo(any(), any()) }
+    }
+
+    @Test
+    fun `sync should only delete entries that are stale`() = runBlocking {
+        val nfsCpa = mapOf("nav:qass:12345" to "2024-01-01T00:00:00Z")
+        val dbCpa = mapOf(
+            "nav:qass:12345" to "2024-01-01T00:00:00Z",
+            "nav:qass:67890" to "2024-01-01T00:00:00Z"
         )
-        val mockedNFSConnector = mockNFSConnector(entries)
-        cpaSyncService = CpaSyncService(cpaRepoClient, mockedNFSConnector)
 
-        coEvery { cpaRepoClient.getCPATimestamps() } returns cpaTimestampsFromDb
+        val mockNfs = mockNfsFromMap(nfsCpa)
+        mockCpaRepoFromMap(dbCpa)
 
+        val cpaSyncService = CpaSyncService(mockCpaRepoClient, mockNfs)
         cpaSyncService.sync()
+
+        coVerify(exactly = 1) { mockCpaRepoClient.deleteCPAinCPARepo("nav:qass:67890") }
+    }
+
+    @Test
+    fun `sync should delete and upsert in same sync`() = runBlocking {
+        val nfsCpa = mapOf("nav:qass:12345" to "2024-01-01T00:00:00Z")
+        val dbCpa = mapOf("nav:qass:67890" to "2024-01-01T00:00:00Z")
+
+        val mockNfs = mockNfsFromMap(nfsCpa)
+        mockCpaRepoFromMap(dbCpa)
+
+        val cpaSyncService = CpaSyncService(mockCpaRepoClient, mockNfs)
+        cpaSyncService.sync()
+
+        coVerify(exactly = 1) { mockCpaRepoClient.putCPAinCPARepo(any(), any()) }
+        coVerify(exactly = 1) { mockCpaRepoClient.deleteCPAinCPARepo("nav:qass:67890") }
+    }
+
+    @Test
+    fun `sync should upsert correct CPA content`() = runBlocking {
+        val nfsCpa = mapOf("nav:qass:12345" to "2024-01-01T00:00:00Z")
+        val dbCpa = emptyMap<String, String>()
+
+        val mockNfs = mockNfsFromMap(nfsCpa)
+        mockCpaRepoFromMap(dbCpa)
+
+        val cpaSyncService = CpaSyncService(mockCpaRepoClient, mockNfs)
+        cpaSyncService.sync()
+
+        val expectedFileContent = """
+            <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+            <cppa:CollaborationProtocolAgreement cppa:cpaid="nav:qass:12345">
+                <!-- CPA content removed -->
+            </cppa:CollaborationProtocolAgreement>
+        """.trimIndent()
 
         coVerify(exactly = 1) {
-            cpaRepoClient.putCPAinCPARepo(
-                "simulated file content for /outbound/cpa/cpa2.xml",
-                any()
-            )
+            mockCpaRepoClient.putCPAinCPARepo(expectedFileContent, "2024-01-01T00:00:00Z")
         }
-        coVerify(exactly = 0) { cpaRepoClient.deleteCPAinCPARepo(any()) }
     }
 
     @Test
-    fun `sync should update existing entry into our database after it have been modified in files`() = runBlocking {
-        val lastModifiedDifferentThanFile = "2023-11-01T00:00:00Z"
-        val cpaTimestampsFromDb =
-            mutableMapOf("cpa1" to lastModifiedDifferentThanFile, "cpa2" to "2024-01-01T00:00:00Z")
-        val mockedAttrs = mockSftpAttrs(1704067200)
-        val entries = listOf(
-            mockLsEntry("cpa1.xml", mockedAttrs),
-            mockLsEntry("cpa2.xml", mockedAttrs)
-        )
-        val mockedNFSConnector = mockNFSConnector(entries)
-        cpaSyncService = CpaSyncService(cpaRepoClient, mockedNFSConnector)
-        coEvery { cpaRepoClient.getCPATimestamps() } returns cpaTimestampsFromDb
-
-        cpaSyncService.sync()
-
-        coVerify(exactly = 1) {
-            cpaRepoClient.putCPAinCPARepo(
-                "simulated file content for /outbound/cpa/cpa1.xml",
-                any()
-            )
+    fun `multiple syncs should persist CPA only once`() = runBlocking {
+        val lsEntry = mockLsEntry("nav.qass.12345.xml", "2025-01-01T00:00:00Z")
+        val mockNfs: NFSConnector = mockk {
+            every { folder() } returns Vector<ChannelSftp.LsEntry>().apply { add(lsEntry) }
+            every { file(any()) } answers { ByteArrayInputStream(simulateFileContent("nav:qass:12345").toByteArray()) }
+            every { close() } just Runs
         }
-        coVerify(exactly = 0) { cpaRepoClient.deleteCPAinCPARepo(any()) }
-    }
 
-    @Test
-    fun `sync should update an existing entry cpa1 and delete old entry cpa2 in database`() = runBlocking {
-        val lastModifiedDifferentThanFile = "2023-11-01T00:00:00Z"
-        val cpaTimestampsFromDb =
-            mutableMapOf("cpa1" to lastModifiedDifferentThanFile, "cpa2" to "2024-01-01T00:00:00Z")
-        val mockedAttrs = mockSftpAttrs(1704067200)
-        val entries = listOf(
-            mockLsEntry("cpa1.xml", mockedAttrs)
-        )
-        val mockedNFSConnector = mockNFSConnector(entries)
-        cpaSyncService = CpaSyncService(cpaRepoClient, mockedNFSConnector)
-        coEvery { cpaRepoClient.getCPATimestamps() } returns cpaTimestampsFromDb
+        val dbCpaMapFirst = mapOf("nav:qass:12345" to "2024-01-01T00:00:00Z")
+        val dbCpaMapSecond = mapOf("nav:qass:12345" to "2025-01-01T00:00:00Z")
 
-        cpaSyncService.sync()
-
-        coVerify(exactly = 1) {
-            cpaRepoClient.putCPAinCPARepo(
-                "simulated file content for /outbound/cpa/cpa1.xml",
-                any()
-            )
-        }
-        coVerify(exactly = 1) { cpaRepoClient.deleteCPAinCPARepo("cpa2") }
-    }
-
-    @Test
-    fun `sync should insert new entry into our database only once`() = runBlocking {
-        val firstRunCpaTimestampsFromDb = mutableMapOf("cpa1" to "2024-01-01T00:00:00Z")
-        val secondRunCpaTimestampsFromDb =
-            mutableMapOf("cpa1" to "2024-01-01T00:00:00Z", "cpa2" to "2024-01-01T00:00:00Z")
         var callCount = 0
-
-        coEvery { cpaRepoClient.getCPATimestamps() } answers {
+        coEvery { mockCpaRepoClient.getCPATimestamps() } answers {
             callCount++
             when (callCount) {
-                1 -> firstRunCpaTimestampsFromDb
-                else -> secondRunCpaTimestampsFromDb
+                1 -> dbCpaMapFirst
+                else -> dbCpaMapSecond
             }
         }
 
-        val mockedAttrs = mockSftpAttrs(1704067200)
-        val entries = listOf(
-            mockLsEntry("cpa1.xml", mockedAttrs),
-            mockLsEntry("cpa2.xml", mockedAttrs)
-        )
-        val mockedNFSConnector = mockNFSConnector(entries)
-        cpaSyncService = CpaSyncService(cpaRepoClient, mockedNFSConnector)
+        val cpaSyncService = CpaSyncService(mockCpaRepoClient, mockNfs)
 
-        cpaSyncService.sync()
         cpaSyncService.sync()
         cpaSyncService.sync()
         cpaSyncService.sync()
 
         coVerify(exactly = 1) {
-            cpaRepoClient.putCPAinCPARepo(
-                "simulated file content for /outbound/cpa/cpa2.xml",
-                any()
-            )
+            mockCpaRepoClient.putCPAinCPARepo(any(), any())
         }
         coVerify(exactly = 0) {
-            cpaRepoClient.putCPAinCPARepo(
-                eq("simulated file content for /outbound/cpa/cpa1.xml"),
-                any()
-            )
-        }
-        coVerify(exactly = 1) {
-            cpaRepoClient.putCPAinCPARepo(
-                eq("simulated file content for /outbound/cpa/cpa2.xml"),
-                any()
-            )
+            mockCpaRepoClient.deleteCPAinCPARepo(any())
         }
     }
 
     @Test
-    fun `shouldSkipFile should return false (not skip) if the filename is not contained in mutable map`() {
-        val filename = "cpa1.xml"
-        val lastModified = Instant.parse("2024-01-01T00:00:00Z")
-        val cpaTimestamps = mutableMapOf("cpa2" to "2023-12-31T23:59:59Z", "cpa3" to "2023-11-30T23:59:59Z")
-        val mockedNFSConnector = mockNFSConnector(emptyList())
-        cpaSyncService = spyk(CpaSyncService(cpaRepoClient, mockedNFSConnector))
+    fun `upsert check should return true if nfs timestamp is newer than db timestamp`() {
+        val cpaSyncService = CpaSyncService(mockCpaRepoClient, mockNFSConnector)
 
-        val shouldSkip = cpaSyncService.shouldSkipFile(filename, lastModified, cpaTimestamps)
-
-        assertFalse(shouldSkip)
-    }
-
-    @Test
-    fun `shouldSkipFile should return true (skip) if the filename is found and we have a matching timestamp`() {
-        val filename = "nav.10086.xml"
-        val lastModified = Instant.parse("2022-12-30T20:14:50Z")
-        val cpaTimestamps = mutableMapOf("nav:10086" to "2022-12-30T20:14:50Z")
-        val mockedNFSConnector = mockNFSConnector(emptyList())
-        cpaSyncService = spyk(CpaSyncService(cpaRepoClient, mockedNFSConnector))
-
-        val shouldSkip = cpaSyncService.shouldSkipFile(filename, lastModified, cpaTimestamps)
-
-        assertTrue(shouldSkip)
-    }
-
-    @Test
-    fun `shouldSkipFile should return true (skip) if the filename is contained in mutable map`() {
-        val filename = "cpa1.xml"
-        val lastModified = Instant.parse("2024-01-01T00:00:00Z")
-        val cpaTimestamps = mutableMapOf("cpa1" to "2024-01-01T00:00:00Z", "cpa2" to "2023-12-31T23:59:59Z")
-        val mockedNFSConnector = mockNFSConnector(emptyList())
-        cpaSyncService = spyk(CpaSyncService(cpaRepoClient, mockedNFSConnector))
-
-        val shouldSkip = cpaSyncService.shouldSkipFile(filename, lastModified, cpaTimestamps)
-
-        assertTrue(shouldSkip)
-    }
-
-    @Test
-    fun `deleteStaleCpaEntries should delete remaining timestamps`() = runBlocking {
-        val cpaTimestamps = mutableMapOf("cpa1" to "2024-01-01T00:00:00Z")
-        val mockedNFSConnector = mockNFSConnector(emptyList())
-        cpaSyncService = spyk(CpaSyncService(cpaRepoClient, mockedNFSConnector))
-
-        cpaSyncService.deleteStaleCpaEntries(cpaTimestamps)
-
-        coVerify { cpaRepoClient.deleteCPAinCPARepo("cpa1") }
+        assertTrue { cpaSyncService.shouldUpsertCpa("2025-01-01T00:00:00Z", null) }
+        assertTrue { cpaSyncService.shouldUpsertCpa("2025-01-01T00:00:00Z", "2024-01-01T00:00:00Z") }
+        assertFalse { cpaSyncService.shouldUpsertCpa("2024-01-01T00:00:00Z", "2025-01-01T00:00:00Z") }
+        assertFalse { cpaSyncService.shouldUpsertCpa("2024-01-01T00:00:00Z", "2024-01-01T00:00:00Z") }
     }
 
     @Test
     fun `sync should handle SftpException`() = runBlocking {
         val expectedSftpException = SftpException(4, "SFTP error")
-        coEvery { cpaRepoClient.getCPATimestamps() } throws expectedSftpException
-        val mockedNFSConnector = mockNFSConnector(emptyList())
-        cpaSyncService = spyk(CpaSyncService(cpaRepoClient, mockedNFSConnector))
+        coEvery { mockCpaRepoClient.getCPATimestamps() } throws expectedSftpException
+        val mockedNFSConnector = mockNfsFromMap(emptyMap())
+        val cpaSyncService = spyk(CpaSyncService(mockCpaRepoClient, mockedNFSConnector))
 
         val resultException = assertFailsWith<SftpException> {
             cpaSyncService.sync()
@@ -267,10 +320,10 @@ class CpaSyncServiceTest {
     @Test
     fun `sync should handle a generic exception`() = runBlocking {
         val expectedException = Exception("generic error")
-        coEvery { cpaRepoClient.getCPATimestamps() } throws expectedException
+        coEvery { mockCpaRepoClient.getCPATimestamps() } throws expectedException
 
-        val mockedNFSConnector = mockNFSConnector(emptyList())
-        cpaSyncService = spyk(CpaSyncService(cpaRepoClient, mockedNFSConnector))
+        val mockedNFSConnector = mockNfsFromMap(emptyMap())
+        val cpaSyncService = spyk(CpaSyncService(mockCpaRepoClient, mockedNFSConnector))
 
         val resultException = assertFailsWith<Exception> {
             cpaSyncService.sync()
@@ -280,31 +333,44 @@ class CpaSyncServiceTest {
         verify { cpaSyncService.logFailure(expectedException) }
     }
 
-    @Test
-    fun `mTime to seconds should be accurate`() {
-        val mTimeInSeconds = 1686480930L
-        val expectedInstant = Instant.parse("2023-06-11T10:55:30Z")
-
-        val mockedNFSConnector = mockNFSConnector(emptyList())
-        cpaSyncService = CpaSyncService(cpaRepoClient, mockedNFSConnector)
-
-        val resultInstant = cpaSyncService.getLastModifiedInstant(mTimeInSeconds)
-
-        assert(expectedInstant == resultInstant)
+    private fun mockCpaRepoFromMap(dbCpaMap: Map<String, String>) {
+        coEvery { mockCpaRepoClient.getCPATimestamps() } returns dbCpaMap
     }
 
-    private fun mockSftpAttrs(mTime: Int): SftpATTRS = mockk {
-        every { this@mockk.mTime } returns mTime
+    private fun mockNfsFromMap(nfsCpaMap: Map<String, String>): NFSConnector {
+        val lsEntries = nfsCpaMap.map { mockLsEntry(createFilename(it.key), it.value) }
+
+        return mockNfsFromEntries(lsEntries, nfsCpaMap.keys.toList())
     }
 
-    private fun mockLsEntry(filename: String, attrs: SftpATTRS): ChannelSftp.LsEntry = mockk {
-        every { this@mockk.filename } returns filename
-        every { this@mockk.attrs } returns attrs
+    private fun mockNfsFromEntries(lsEntries: List<ChannelSftp.LsEntry>, nfsCpaIds: List<String>): NFSConnector {
+        return mockk {
+            every { folder() } returns Vector<ChannelSftp.LsEntry>().apply { addAll(lsEntries) }
+            every { file(any()) } returnsMany nfsCpaIds.map { ByteArrayInputStream(simulateFileContent(it).toByteArray()) }
+            every { close() } just Runs
+        }
     }
 
-    private fun mockNFSConnector(entries: List<ChannelSftp.LsEntry>): NFSConnector = mockk {
-        every { folder() } returns Vector<ChannelSftp.LsEntry>().apply { addAll(entries) }
-        every { file(any()) } answers { ByteArrayInputStream("simulated file content for ${it.invocation.args[0]}".toByteArray()) }
-        every { close() } just Runs
+    private fun mockLsEntry(entryName: String, timestamp: String): ChannelSftp.LsEntry =
+        mockk {
+            every { filename } returns entryName
+            every { attrs } returns mockSftpAttrs(timestamp)
+        }
+
+    private fun mockSftpAttrs(timestamp: String): SftpATTRS = mockk {
+        every { mTime } returns Instant.parse(timestamp).epochSecond.toInt()
+    }
+
+    private fun createFilename(cpaId: String): String {
+        return "${cpaId.replace(":", ".")}.xml"
+    }
+
+    private fun simulateFileContent(cpaId: String): String {
+        return """
+            <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+            <cppa:CollaborationProtocolAgreement cppa:cpaid="$cpaId">
+                <!-- CPA content removed -->
+            </cppa:CollaborationProtocolAgreement>
+        """.trimIndent()
     }
 }

--- a/smtp-listeners/src/test/resources/cpa/nav.qass.12345.xml
+++ b/smtp-listeners/src/test/resources/cpa/nav.qass.12345.xml
@@ -1,0 +1,581 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<cppa:CollaborationProtocolAgreement xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:cppa="http://www.oasis-open.org/committees/ebxml-cppa/schema/cpp-cpa-2_0.xsd" xmlns:ns3="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" cppa:cpaid="nav:qass:12345" cppa:version="2_0b" xsi:schemaLocation="http://www.oasis-open.org/committees/ebxml-cppa/schema/cpp-cpa-2_0.xsd cpp-cpa-2_0.xsd">
+    <cppa:Status cppa:value="proposed"/>
+    <cppa:Start>2023-09-26T11:19:19.000Z</cppa:Start>
+    <cppa:End>2025-09-07T21:59:00.000Z</cppa:End>
+    <cppa:PartyInfo cppa:partyName="TEST A1 Haugerud" cppa:defaultMshChannelId="Partner_channelSMTP0_partner" cppa:defaultMshPackageId="Partner_package_mshsignal">
+        <cppa:PartyId cppa:type="HER">8090595</cppa:PartyId>
+        <cppa:PartyId cppa:type="orgnummer">984886136</cppa:PartyId>
+        <cppa:PartyId cppa:type="ENH">984886136</cppa:PartyId>
+        <cppa:PartyRef ns3:type="simple" ns3:href="https://www.nav.no/about.html"/>
+        <cppa:CollaborationRole>
+            <cppa:ProcessSpecification cppa:name="Reseptoppgjor" cppa:version="2.5" cppa:uuid="9584df74-571a-487f-bc5c-jj438sg294bd " ns3:type="simple" ns3:href="http://www.helsedirektoratet.no/processes/eResept.xml"/>
+            <cppa:Role cppa:name="Utleverer" ns3:type="simple" ns3:href="http://www.nav.no/processes#Utleverer"/>
+            <cppa:ApplicationCertificateRef cppa:certId="Partner_cert_crypt_partner"/>
+            <cppa:ServiceBinding>
+                <cppa:Service cppa:type="string">OppgjorsKontroll</cppa:Service>
+                <cppa:CanSend>
+                    <cppa:ThisPartyActionBinding cppa:id="Partner_Oppgjorskrav60" cppa:action="Oppgjorskrav" cppa:packageId="Partner_package_oppgjorskrav_v2p5" ns3:type="simple">
+                        <cppa:BusinessTransactionCharacteristics cppa:isNonRepudiationRequired="true" cppa:isNonRepudiationReceiptRequired="true" cppa:isConfidential="none" cppa:isAuthenticated="none" cppa:isTamperProof="none" cppa:isAuthorizationRequired="false" cppa:isIntelligibleCheckRequired="false" cppa:timeToPerform="P180M"/>
+                        <cppa:ChannelId>Partner_channelSMTP0_partner</cppa:ChannelId>
+                    </cppa:ThisPartyActionBinding>
+                    <cppa:OtherPartyActionBinding>NAV_Oppgjorskrav6</cppa:OtherPartyActionBinding>
+                </cppa:CanSend>
+                <cppa:CanSend>
+                    <cppa:ThisPartyActionBinding cppa:id="Partner_A0761" cppa:action="Svarmelding" cppa:packageId="Partner_package_apprec_v1p0" ns3:type="simple">
+                        <cppa:BusinessTransactionCharacteristics cppa:isNonRepudiationRequired="true" cppa:isNonRepudiationReceiptRequired="true" cppa:isConfidential="none" cppa:isAuthenticated="none" cppa:isTamperProof="none" cppa:isAuthorizationRequired="false" cppa:isIntelligibleCheckRequired="false" cppa:timeToPerform="P180M"/>
+                        <cppa:ChannelId>Partner_channelSMTP0_partner</cppa:ChannelId>
+                    </cppa:ThisPartyActionBinding>
+                    <cppa:OtherPartyActionBinding>NAV_A076</cppa:OtherPartyActionBinding>
+                </cppa:CanSend>
+                <cppa:CanReceive>
+                    <cppa:ThisPartyActionBinding cppa:id="Partner_Oppgjorsresultat62" cppa:action="Oppgjorsresultat" cppa:packageId="Partner_package_oppgjorsresultat_v2p5" ns3:type="simple">
+                        <cppa:BusinessTransactionCharacteristics cppa:isNonRepudiationRequired="true" cppa:isNonRepudiationReceiptRequired="true" cppa:isConfidential="none" cppa:isAuthenticated="none" cppa:isTamperProof="none" cppa:isAuthorizationRequired="false" cppa:isIntelligibleCheckRequired="false" cppa:timeToPerform="P180M"/>
+                        <cppa:ChannelId>Partner_channelSMTP0_partner</cppa:ChannelId>
+                    </cppa:ThisPartyActionBinding>
+                    <cppa:OtherPartyActionBinding>NAV_Oppgjorsresultat6</cppa:OtherPartyActionBinding>
+                </cppa:CanReceive>
+                <cppa:CanReceive>
+                    <cppa:ThisPartyActionBinding cppa:id="Partner_Utbetaling63" cppa:action="Utbetaling" cppa:packageId="Partner_package_utbetaling_v2p5" ns3:type="simple">
+                        <cppa:BusinessTransactionCharacteristics cppa:isNonRepudiationRequired="true" cppa:isNonRepudiationReceiptRequired="true" cppa:isConfidential="none" cppa:isAuthenticated="none" cppa:isTamperProof="none" cppa:isAuthorizationRequired="false" cppa:isIntelligibleCheckRequired="false" cppa:timeToPerform="P180M"/>
+                        <cppa:ChannelId>Partner_channelSMTP0_partner</cppa:ChannelId>
+                    </cppa:ThisPartyActionBinding>
+                    <cppa:OtherPartyActionBinding>NAV_Utbetaling6</cppa:OtherPartyActionBinding>
+                </cppa:CanReceive>
+                <cppa:CanReceive>
+                    <cppa:ThisPartyActionBinding cppa:id="Partner_Bekreftelse64" cppa:action="Svarmelding" cppa:packageId="Partner_package_apprec_v1p0" ns3:type="simple">
+                        <cppa:BusinessTransactionCharacteristics cppa:isNonRepudiationRequired="true" cppa:isNonRepudiationReceiptRequired="true" cppa:isConfidential="none" cppa:isAuthenticated="none" cppa:isTamperProof="none" cppa:isAuthorizationRequired="false" cppa:isIntelligibleCheckRequired="false" cppa:timeToPerform="P180M"/>
+                        <cppa:ChannelId>Partner_channelSMTP0_partner</cppa:ChannelId>
+                    </cppa:ThisPartyActionBinding>
+                    <cppa:OtherPartyActionBinding>NAV_Bekreftelse6</cppa:OtherPartyActionBinding>
+                </cppa:CanReceive>
+            </cppa:ServiceBinding>
+        </cppa:CollaborationRole>
+        <cppa:CollaborationRole>
+            <cppa:ProcessSpecification cppa:name="EgenandelFritak" cppa:version="1.0" cppa:uuid="b9b31088-eb0a-42ca-a47d-37f025958f02" ns3:type="simple" ns3:href="http://www.helsedirektoratet.no/processes/Egenandel.xml"/>
+            <cppa:Role cppa:name="Utleverer" ns3:type="simple" ns3:href="http://www.nav.no/processes#Utleverer"/>
+            <cppa:ApplicationCertificateRef cppa:certId="Partner_cert_crypt_partner"/>
+            <cppa:ServiceBinding>
+                <cppa:Service cppa:type="string">HarBorgerEgenandelFritak</cppa:Service>
+                <cppa:CanSend>
+                    <cppa:ThisPartyActionBinding cppa:id="Partner_EgenandelFritak_EgenandelForesporsel0" cppa:action="EgenandelForesporsel" cppa:packageId="Partner_package_egenandelforesporsel_v1p0" ns3:type="simple">
+                        <cppa:BusinessTransactionCharacteristics cppa:isNonRepudiationRequired="true" cppa:isNonRepudiationReceiptRequired="true" cppa:isConfidential="none" cppa:isAuthenticated="none" cppa:isTamperProof="none" cppa:isAuthorizationRequired="false" cppa:isIntelligibleCheckRequired="false" cppa:timeToPerform="P180M"/>
+                        <cppa:ChannelId>Partner_channelHTTP1_partner</cppa:ChannelId>
+                    </cppa:ThisPartyActionBinding>
+                    <cppa:OtherPartyActionBinding>NAV_EgenandelFritak_EgenandelForesporsel</cppa:OtherPartyActionBinding>
+                </cppa:CanSend>
+                <cppa:CanReceive>
+                    <cppa:ThisPartyActionBinding cppa:id="Partner_EgenandelFritak_Svar1" cppa:action="Svar" cppa:packageId="Partner_package_egenandelsvar_v1p0" ns3:type="simple">
+                        <cppa:BusinessTransactionCharacteristics cppa:isNonRepudiationRequired="true" cppa:isNonRepudiationReceiptRequired="true" cppa:isConfidential="none" cppa:isAuthenticated="none" cppa:isTamperProof="none" cppa:isAuthorizationRequired="false" cppa:isIntelligibleCheckRequired="false" cppa:timeToPerform="P180M"/>
+                        <cppa:ChannelId>Partner_channelHTTP1_partner</cppa:ChannelId>
+                    </cppa:ThisPartyActionBinding>
+                    <cppa:OtherPartyActionBinding>NAV_EgenandelFritak_Svar</cppa:OtherPartyActionBinding>
+                </cppa:CanReceive>
+                <cppa:CanReceive>
+                    <cppa:ThisPartyActionBinding cppa:id="Partner_EgenandelFritak_Avvisning2" cppa:action="Avvisning" cppa:packageId="Partner_package_apprec_v1p0" ns3:type="simple">
+                        <cppa:BusinessTransactionCharacteristics cppa:isNonRepudiationRequired="true" cppa:isNonRepudiationReceiptRequired="true" cppa:isConfidential="none" cppa:isAuthenticated="none" cppa:isTamperProof="none" cppa:isAuthorizationRequired="false" cppa:isIntelligibleCheckRequired="false" cppa:timeToPerform="P180M"/>
+                        <cppa:ChannelId>Partner_channelHTTP1_partner</cppa:ChannelId>
+                    </cppa:ThisPartyActionBinding>
+                    <cppa:OtherPartyActionBinding>NAV_EgenandelFritak_Avvisning</cppa:OtherPartyActionBinding>
+                </cppa:CanReceive>
+            </cppa:ServiceBinding>
+        </cppa:CollaborationRole>
+        <cppa:Certificate cppa:certId="Partner_cert_sign_partner">
+            <ds:KeyInfo>
+<ds:X509Data>
+                    <ds:X509Certificate>MIIGaDCCBFCgAwIBAgILAZtVR0IY/1EvjtowDQYJKoZIhvcNAQELBQAwbjELMAkGA1UEBhMCTk8xGDAWBgNVBGEMD05UUk5PLTk4MzE2MzMyNzETMBEGA1UECgwKQnV5cGFzcyBBUzEwMC4GA1UEAwwnQnV5cGFzcyBDbGFzcyAzIFRlc3Q0IENBIEcyIFNUIEJ1c2luZXNzMB4XDTIzMDgyODA4MzQzM1oXDTI2MDgyODIxNTkwMFowgYsxCzAJBgNVBAYTAk5PMRwwGgYDVQQKDBNBUE9URUsgMSBHUlVQUEVOIEFTMSkwJwYDVQQLDCBFUjpOTy05ODQ4ODYxMzYtVEVTVCBBMSBIYXVnZXJ1ZDEZMBcGA1UEAwwQVEVTVCBBMSBIYXVnZXJ1ZDEYMBYGA1UEYQwPTlRSTk8tOTgzMDQ0Nzc4MIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEA1HE+rxisqKWgFOnqAtyig+2vpadevrgTfbhQsZ4A0tevblgURDat2y5cMMqOI5FAXym+0KGooCdupZZGb1G9mmII5/clW2FkeeqvVBcJ5WCUynEuYd+v6dhMAdvgc3ZNgdlqey3amXyhF9YWkQPoaBLyfIjYzsBak3A5FfAUmcCAt3Fh2k7SkfvGypYVVEDeKBFnD/sxAuWBgolc+go+ylvSZdHbAEsaHGJAXBz3fTFKkPwng8dRPQRYCd34/FcKXdl15U2CdOLkMiqy4+qQRckJFKppa40COR7WVStJ3Tq41VqxDrPeqoigUySmNQ2g27nXS7EpPfKoKr/MSVo92euna4yLtKXnbUi9vPcmnb6BQn0CNe4YesHCq7Evt7Cc0ksxBzxN4YXNkCD+EonMnTL0d5K937Pm6QCF0UMHE55UmrCXKYAPsKkhmicfVz7+nhg5+ZDKmjY6rjNC2ro23Jy6B9jdu7v4/J+55Tsq+XWrcgX6RD6M4WV4HDH7HkTrAgMBAAGjggFnMIIBYzAJBgNVHRMEAjAAMB8GA1UdIwQYMBaAFKf+u2xZiK10LkZeemj50bu/z7aLMB0GA1UdDgQWBBQe9sgFd28eFxkwaNNs9uOuEIfIpTAOBgNVHQ8BAf8EBAMCBkAwHwYDVR0gBBgwFjAKBghghEIBGgEDAjAIBgYEAI96AQEwQQYDVR0fBDowODA2oDSgMoYwaHR0cDovL2NybC50ZXN0NC5idXlwYXNzY2EuY29tL0JQQ2wzQ2FHMlNUQlMuY3JsMHsGCCsGAQUFBwEBBG8wbTAtBggrBgEFBQcwAYYhaHR0cDovL29jc3Bicy50ZXN0NC5idXlwYXNzY2EuY29tMDwGCCsGAQUFBzAChjBodHRwOi8vY3J0LnRlc3Q0LmJ1eXBhc3NjYS5jb20vQlBDbDNDYUcyU1RCUy5jZXIwJQYIKwYBBQUHAQMEGTAXMBUGCCsGAQUFBwsCMAkGBwQAi+xJAQIwDQYJKoZIhvcNAQELBQADggIBAGNRk/LOxpWr4gGgF6iJYdu3m5eWqYTlfX2XI9irs1Xg4kY+TPNyhAu5p7wEZ3olT3f0xnnhzSLN6dl942dJwVdVNmrPQj9hoduxC2+79PKMOwFInbaKV+dRrJe1C/cMmCtCOnUfRQP7nG91Yy2t1XS8KDGZPo+ZxpT8Knhywi/cGjQJrx0JR+LR6EYeFPdafEBoBhnHGpbqWRbj/Ee+POMieK8S7UE62grcw1IvowUwm2PSARrRDl3BFduxOZq9+AImpQvP+i6hXu591jRAwn7bJC7WvY/xEgfDB7tgsHdojT5jbjhlAtUCpaENTM6J2bmhBxAORb+4rnV2cmuuOzr0m9LiJoanNEZFpGp4BFe40SEvpohpuZ1qFJlX1TyRcnl+CtUHLmtIsMpsgMJh0gGA6vVnHjyO9BA669z6NalHad/mdKdRzVM80qP2NsGiK8esM9q7WV20VmD2XTwmQBVxohsXg2TGr7V0+8mwudJ2kB0LzPiAaiSZmb2QP0qctY+HkJvZFMNMg26Bg+q3LWbJaGJWHwmehXYu3ttpWkd+5RhGZFmCx944PdQ2e0+EGUTKjbDwLKPizFGnVlnSDjCVSynUGB3GFkPqlv02FQthsidGXdZjJz9fLpuG4y0aQZiMZKtehJHQ2YQeAn/6xkZpBSIbokL9NjuWya8Qp0gl</ds:X509Certificate>
+                </ds:X509Data>
+            </ds:KeyInfo>
+        </cppa:Certificate>
+        <cppa:Certificate cppa:certId="Partner_cert_crypt_partner">
+            <ds:KeyInfo>
+<ds:X509Data>
+                    <ds:X509Certificate>MIIGaDCCBFCgAwIBAgILAZtUwpivGrpxPEAwDQYJKoZIhvcNAQELBQAwbjELMAkGA1UEBhMCTk8xGDAWBgNVBGEMD05UUk5PLTk4MzE2MzMyNzETMBEGA1UECgwKQnV5cGFzcyBBUzEwMC4GA1UEAwwnQnV5cGFzcyBDbGFzcyAzIFRlc3Q0IENBIEcyIFNUIEJ1c2luZXNzMB4XDTIzMDgyODA4MzQzM1oXDTI2MDgyODIxNTkwMFowgYsxCzAJBgNVBAYTAk5PMRwwGgYDVQQKDBNBUE9URUsgMSBHUlVQUEVOIEFTMSkwJwYDVQQLDCBFUjpOTy05ODQ4ODYxMzYtVEVTVCBBMSBIYXVnZXJ1ZDEZMBcGA1UEAwwQVEVTVCBBMSBIYXVnZXJ1ZDEYMBYGA1UEYQwPTlRSTk8tOTgzMDQ0Nzc4MIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEAqnage0tLYeTXM7SUN1d91s9ShpDHN26Psd4PpVVKueDqbrTs1kvU8WrkPbDB2sJbaOEzgMUPDL1T/WKk2NDyM+xAPDde/xblk/upa+nMeSggy6h9MnEeDliKxHpRWrZFmBuSjzHh01lS8xapndYOdreNCgObretweTOyMgP8BXL/mufy6cDFG+ZjJvO6fk8tj+4+qR8dQ90bJXH4YZ+NgYVWDimLlaWV4rmCHNUxmI/RTUNr0UF880knjo2QcfWUJ5HGhkq+gKAg2CE8jW1xQa/ZcjeL3xxQyGp3WMdzGIvB2zzfJcdLOkbo/T+gaanN5Iib2+epqTYr3lqSlXIRkeNF/aCAmz/bvRR2mR68pAn9eNyoSA9sickn9SAVzhupq9uG2yC9coLCvjWRxwXCFLDqGcgwPobgP/ev3BT7iFC+qkIJ5tzZQ1Bnijhbdg6kWPuhxwaQN/XTWzbaym6aOdFZcjS9QQBaPJeu2PLxRQ5gXAmfogSPe10gBXUCHXjVAgMBAAGjggFnMIIBYzAJBgNVHRMEAjAAMB8GA1UdIwQYMBaAFKf+u2xZiK10LkZeemj50bu/z7aLMB0GA1UdDgQWBBT0sFa++b4sYKS5mY3bVf0W2yZfETAOBgNVHQ8BAf8EBAMCBaAwHwYDVR0gBBgwFjAKBghghEIBGgEDAjAIBgYEAI96AQEwQQYDVR0fBDowODA2oDSgMoYwaHR0cDovL2NybC50ZXN0NC5idXlwYXNzY2EuY29tL0JQQ2wzQ2FHMlNUQlMuY3JsMHsGCCsGAQUFBwEBBG8wbTAtBggrBgEFBQcwAYYhaHR0cDovL29jc3Bicy50ZXN0NC5idXlwYXNzY2EuY29tMDwGCCsGAQUFBzAChjBodHRwOi8vY3J0LnRlc3Q0LmJ1eXBhc3NjYS5jb20vQlBDbDNDYUcyU1RCUy5jZXIwJQYIKwYBBQUHAQMEGTAXMBUGCCsGAQUFBwsCMAkGBwQAi+xJAQIwDQYJKoZIhvcNAQELBQADggIBAIRkW7kVo5ztKqa8slmOPqMgmA/19bYx3fCZqSDrakHLVkNC+fE3Ra6p4PhtRHkDgm9Eu45osfsdsTB3s1mFA2kKs93CwCOj8/b29ijL+4ZiXMqVXEFUAe1hwq9Cq18Fh1my2HmW7OC9njLnYVMmZ9dwQR9TedoknzQyh2Lw40rt0Rj5G8NoKhky5D0ucCFJYLYoP2mjLsszRfs8eyBB7P7LUhyWW92Q3e4dVirTMz27cS67CEHO+B3FvkUPrK6tUicaTsVQKpnE89pirI5She1vMf6I8h5loIoUWcvF3RClmu+fJEyAlA2wpdSZrrrZ9bZPw4oIY+9u+iydeSzPiZ+KXN0g9UfByVmXRC0bG268CvOwfOhEZhwqPkEV/EGeDNaysGbo7Rwon8hNmPHayUBMai9dwNx4pDMPq7wLBceIa0owfZ4k2psHdo6D5/ubi88udG04Lz6dDthNI6r3956FqbWKZOC5equofrBZvvL598qU+pEqtkzJqyU4JFu+pRG14QmlvzVJf8bKnhhRz+DJfftyoz7x3sg+80dRjafGn1n9ghmP1rJREhfDrCVFRQ9VfP1rfMQKtQUYZN83HkNeUVMi75NLQmFibnAK76PELIjOc/TthRP+Ae0qjsPA07smlebMtrv/1DY1bMwdb89xFRZ8fWKqpUC26afwS1WB</ds:X509Certificate>
+                </ds:X509Data>
+            </ds:KeyInfo>
+        </cppa:Certificate>
+        <cppa:SecurityDetails cppa:securityId="Partner_initiator_transport_security"/>
+        <cppa:DeliveryChannel cppa:channelId="Partner_channelSMTP0_partner" cppa:transportId="Partner_transportSMTP0_partner" cppa:docExchangeId="Partner_docexchange_smtp_eresept">
+            <cppa:MessagingCharacteristics cppa:syncReplyMode="none" cppa:ackRequested="always" cppa:ackSignatureRequested="always" cppa:duplicateElimination="always"/>
+        </cppa:DeliveryChannel>
+        <cppa:DeliveryChannel cppa:channelId="Partner_channelHTTP1_partner" cppa:transportId="Partner_transportHTTP1_partner" cppa:docExchangeId="Partner_docexchange_http">
+            <cppa:MessagingCharacteristics cppa:syncReplyMode="signalsAndResponse" cppa:ackRequested="never" cppa:ackSignatureRequested="never" cppa:duplicateElimination="never"/>
+        </cppa:DeliveryChannel>
+        <cppa:Transport cppa:transportId="Partner_transportSMTP0_partner">
+            <cppa:TransportSender>
+                <cppa:TransportProtocol cppa:version="1.1">SMTP</cppa:TransportProtocol>
+            </cppa:TransportSender>
+            <cppa:TransportReceiver>
+                <cppa:TransportProtocol cppa:version="1.1">SMTP</cppa:TransportProtocol>
+                <cppa:Endpoint cppa:uri="mailto://TEST_A1_Haugerud_t1@edi.nhn.no" cppa:type="allPurpose"/>
+            </cppa:TransportReceiver>
+        </cppa:Transport>
+        <cppa:Transport cppa:transportId="Partner_transportHTTP1_partner">
+            <cppa:TransportSender>
+                <cppa:TransportProtocol cppa:version="1.1">HTTP</cppa:TransportProtocol>
+                <cppa:TransportClientSecurity>
+                    <cppa:TransportSecurityProtocol cppa:version="3.0">SSL</cppa:TransportSecurityProtocol>
+                </cppa:TransportClientSecurity>
+            </cppa:TransportSender>
+            <cppa:TransportReceiver>
+                <cppa:TransportProtocol cppa:version="1.1">HTTP</cppa:TransportProtocol>
+                <cppa:Endpoint cppa:uri="http://foo.bar" cppa:type="allPurpose"/>
+            </cppa:TransportReceiver>
+        </cppa:Transport>
+        <cppa:DocExchange cppa:docExchangeId="Partner_docexchange_smtp_eresept">
+            <cppa:ebXMLSenderBinding cppa:version="2.0">
+                <cppa:ReliableMessaging>
+                    <cppa:Retries>4</cppa:Retries>
+                    <cppa:RetryInterval>PT240M</cppa:RetryInterval>
+                    <cppa:MessageOrderSemantics>NotGuaranteed</cppa:MessageOrderSemantics>
+                </cppa:ReliableMessaging>
+                <cppa:PersistDuration>P2D</cppa:PersistDuration>
+                <cppa:SenderNonRepudiation>
+                    <cppa:NonRepudiationProtocol cppa:version="string">http://www.w3.org/2000/09/xmldsig#</cppa:NonRepudiationProtocol>
+                    <cppa:HashFunction>http://www.w3.org/2001/04/xmlenc#sha256</cppa:HashFunction>
+                    <cppa:SignatureAlgorithm cppa:oid="1.2.840.113549.1.1.5" cppa:w3c="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256">http://www.w3.org/2001/04/xmldsig-more#rsa-sha256</cppa:SignatureAlgorithm>
+                    <cppa:SigningCertificateRef cppa:certId="Partner_cert_sign_partner"/>
+                </cppa:SenderNonRepudiation>
+            </cppa:ebXMLSenderBinding>
+            <cppa:ebXMLReceiverBinding cppa:version="2.0">
+                <cppa:ReliableMessaging>
+                    <cppa:Retries>4</cppa:Retries>
+                    <cppa:RetryInterval>PT240M</cppa:RetryInterval>
+                    <cppa:MessageOrderSemantics>NotGuaranteed</cppa:MessageOrderSemantics>
+                </cppa:ReliableMessaging>
+                <cppa:PersistDuration>P2D</cppa:PersistDuration>
+                <cppa:ReceiverNonRepudiation>
+                    <cppa:NonRepudiationProtocol cppa:version="string">http://www.w3.org/2000/09/xmldsig#</cppa:NonRepudiationProtocol>
+                    <cppa:HashFunction>http://www.w3.org/2001/04/xmlenc#sha256</cppa:HashFunction>
+                    <cppa:SignatureAlgorithm cppa:oid="1.2.840.113549.1.1.5" cppa:w3c="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256">http://www.w3.org/2001/04/xmldsig-more#rsa-sha256</cppa:SignatureAlgorithm>
+                </cppa:ReceiverNonRepudiation>
+            </cppa:ebXMLReceiverBinding>
+        </cppa:DocExchange>
+        <cppa:DocExchange cppa:docExchangeId="Partner_docexchange_http">
+            <cppa:ebXMLSenderBinding cppa:version="2.0">
+                <cppa:SenderNonRepudiation>
+                    <cppa:NonRepudiationProtocol>http://www.w3.org/2000/09/xmldsig#</cppa:NonRepudiationProtocol>
+                    <cppa:HashFunction>http://www.w3.org/2001/04/xmlenc#sha256</cppa:HashFunction>
+                    <cppa:SignatureAlgorithm cppa:oid="1.2.840.113549.1.1.5" cppa:w3c="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256">http://www.w3.org/2001/04/xmldsig-more#rsa-sha256</cppa:SignatureAlgorithm>
+                    <cppa:SigningCertificateRef cppa:certId="Partner_cert_sign_partner"/>
+                </cppa:SenderNonRepudiation>
+            </cppa:ebXMLSenderBinding>
+            <cppa:ebXMLReceiverBinding cppa:version="2.0">
+                <cppa:ReceiverNonRepudiation>
+                    <cppa:NonRepudiationProtocol>
+						http://www.w3.org/2000/09/xmldsig#
+					</cppa:NonRepudiationProtocol>
+                    <cppa:HashFunction>http://www.w3.org/2001/04/xmlenc#sha256</cppa:HashFunction>
+                    <cppa:SignatureAlgorithm cppa:oid="1.2.840.113549.1.1.5" cppa:w3c="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256">http://www.w3.org/2001/04/xmldsig-more#rsa-sha256</cppa:SignatureAlgorithm>
+                </cppa:ReceiverNonRepudiation>
+            </cppa:ebXMLReceiverBinding>
+        </cppa:DocExchange>
+    </cppa:PartyInfo>
+    <cppa:PartyInfo cppa:partyName="NAV" cppa:defaultMshChannelId="NAV_asyncSMTPChannelA2" cppa:defaultMshPackageId="NAV_package_mshsignal">
+        <cppa:PartyId cppa:type="HER">79768</cppa:PartyId>
+        <cppa:PartyId cppa:type="ENH">889640782</cppa:PartyId>
+        <cppa:PartyId cppa:type="orgnummer">889640782</cppa:PartyId>
+        <cppa:PartyRef ns3:type="simple" ns3:href="https://www.nav.no/about.html"/>
+        <cppa:CollaborationRole>
+            <cppa:ProcessSpecification cppa:name="Reseptoppgjor" cppa:version="2.5" cppa:uuid="9584df74-571a-487f-bc5c-jj438sg294bd " ns3:type="simple" ns3:href="http://www.helsedirektoratet.no/processes/eResept.xml"/>
+            <cppa:Role cppa:name="KontrollUtbetaler" ns3:type="simple" ns3:href="http://www.helsedirektoratet.no/processes#KontrollUtbetaler"/>
+            <cppa:ApplicationCertificateRef cppa:certId="NAV_default_crypt_cert"/>
+            <cppa:ServiceBinding>
+                <cppa:Service cppa:type="string">OppgjorsKontroll</cppa:Service>
+                <cppa:CanSend>
+                    <cppa:ThisPartyActionBinding cppa:id="NAV_Oppgjorsresultat6" cppa:action="Oppgjorsresultat" cppa:packageId="NAV_package_oppgjorsresultat_v2p5" ns3:type="simple">
+                        <cppa:BusinessTransactionCharacteristics cppa:isNonRepudiationRequired="true" cppa:isNonRepudiationReceiptRequired="true" cppa:isConfidential="none" cppa:isAuthenticated="none" cppa:isTamperProof="none" cppa:isAuthorizationRequired="false" cppa:isIntelligibleCheckRequired="false" cppa:timeToPerform="P180M"/>
+                        <cppa:ChannelId>NAV_asyncSMTPChannelA2</cppa:ChannelId>
+                    </cppa:ThisPartyActionBinding>
+                    <cppa:OtherPartyActionBinding>Partner_Oppgjorsresultat62</cppa:OtherPartyActionBinding>
+                </cppa:CanSend>
+                <cppa:CanSend>
+                    <cppa:ThisPartyActionBinding cppa:id="NAV_Utbetaling6" cppa:action="Utbetaling" cppa:packageId="NAV_package_utbetaling_v2p5" ns3:type="simple">
+                        <cppa:BusinessTransactionCharacteristics cppa:isNonRepudiationRequired="true" cppa:isNonRepudiationReceiptRequired="true" cppa:isConfidential="none" cppa:isAuthenticated="none" cppa:isTamperProof="none" cppa:isAuthorizationRequired="false" cppa:isIntelligibleCheckRequired="false" cppa:timeToPerform="P180M"/>
+                        <cppa:ChannelId>NAV_asyncSMTPChannelA2</cppa:ChannelId>
+                    </cppa:ThisPartyActionBinding>
+                    <cppa:OtherPartyActionBinding>Partner_Utbetaling63</cppa:OtherPartyActionBinding>
+                </cppa:CanSend>
+                <cppa:CanSend>
+                    <cppa:ThisPartyActionBinding cppa:id="NAV_Bekreftelse6" cppa:action="Svarmelding" cppa:packageId="NAV_package_apprec_v1p0" ns3:type="simple">
+                        <cppa:BusinessTransactionCharacteristics cppa:isNonRepudiationRequired="true" cppa:isNonRepudiationReceiptRequired="true" cppa:isConfidential="none" cppa:isAuthenticated="none" cppa:isTamperProof="none" cppa:isAuthorizationRequired="false" cppa:isIntelligibleCheckRequired="false" cppa:timeToPerform="P180M"/>
+                        <cppa:ChannelId>NAV_asyncSMTPChannelA2</cppa:ChannelId>
+                    </cppa:ThisPartyActionBinding>
+                    <cppa:OtherPartyActionBinding>Partner_Bekreftelse64</cppa:OtherPartyActionBinding>
+                </cppa:CanSend>
+                <cppa:CanReceive>
+                    <cppa:ThisPartyActionBinding cppa:id="NAV_Oppgjorskrav6" cppa:action="Oppgjorskrav" cppa:packageId="NAV_package_oppgjorskrav_v2p5" ns3:type="simple">
+                        <cppa:BusinessTransactionCharacteristics cppa:isNonRepudiationRequired="true" cppa:isNonRepudiationReceiptRequired="true" cppa:isConfidential="none" cppa:isAuthenticated="none" cppa:isTamperProof="none" cppa:isAuthorizationRequired="false" cppa:isIntelligibleCheckRequired="false" cppa:timeToPerform="P180M"/>
+                        <cppa:ChannelId>NAV_asyncSMTPChannelA2</cppa:ChannelId>
+                    </cppa:ThisPartyActionBinding>
+                    <cppa:OtherPartyActionBinding>Partner_Oppgjorskrav60</cppa:OtherPartyActionBinding>
+                </cppa:CanReceive>
+                <cppa:CanReceive>
+                    <cppa:ThisPartyActionBinding cppa:id="NAV_A076" cppa:action="Svarmelding" cppa:packageId="NAV_package_apprec_v1p0" ns3:type="simple">
+                        <cppa:BusinessTransactionCharacteristics cppa:isNonRepudiationRequired="true" cppa:isNonRepudiationReceiptRequired="true" cppa:isConfidential="none" cppa:isAuthenticated="none" cppa:isTamperProof="none" cppa:isAuthorizationRequired="false" cppa:isIntelligibleCheckRequired="false" cppa:timeToPerform="P180M"/>
+                        <cppa:ChannelId>NAV_asyncSMTPChannelA2</cppa:ChannelId>
+                    </cppa:ThisPartyActionBinding>
+                    <cppa:OtherPartyActionBinding>Partner_A0761</cppa:OtherPartyActionBinding>
+                </cppa:CanReceive>
+            </cppa:ServiceBinding>
+        </cppa:CollaborationRole>
+        <cppa:CollaborationRole>
+            <cppa:ProcessSpecification cppa:name="EgenandelFritak" cppa:version="1.0" cppa:uuid="b9b31088-eb0a-42ca-a47d-37f025958f02" ns3:type="simple" ns3:href="http://www.helsedirektoratet.no/processes/Egenandel.xml"/>
+            <cppa:Role cppa:name="Frikortregister" ns3:type="simple" ns3:href="http://www.helsedirektoratet.no/processes#Frikortregister"/>
+            <cppa:ApplicationCertificateRef cppa:certId="NAV_default_crypt_cert"/>
+            <cppa:ServiceBinding>
+                <cppa:Service cppa:type="string">HarBorgerEgenandelFritak</cppa:Service>
+                <cppa:CanSend>
+                    <cppa:ThisPartyActionBinding cppa:id="NAV_EgenandelFritak_Svar" cppa:action="Svar" cppa:packageId="NAV_package_egenandelsvar_v1p0" ns3:type="simple">
+                        <cppa:BusinessTransactionCharacteristics cppa:isNonRepudiationRequired="true" cppa:isNonRepudiationReceiptRequired="true" cppa:isConfidential="none" cppa:isAuthenticated="none" cppa:isTamperProof="none" cppa:isAuthorizationRequired="false" cppa:isIntelligibleCheckRequired="false" cppa:timeToPerform="P180M"/>
+                        <cppa:ChannelId>NAV_SyncHttpChannelB1</cppa:ChannelId>
+                    </cppa:ThisPartyActionBinding>
+                    <cppa:OtherPartyActionBinding>Partner_EgenandelFritak_Svar1</cppa:OtherPartyActionBinding>
+                </cppa:CanSend>
+                <cppa:CanSend>
+                    <cppa:ThisPartyActionBinding cppa:id="NAV_EgenandelFritak_Avvisning" cppa:action="Avvisning" cppa:packageId="NAV_package_apprec_v1p0" ns3:type="simple">
+                        <cppa:BusinessTransactionCharacteristics cppa:isNonRepudiationRequired="true" cppa:isNonRepudiationReceiptRequired="true" cppa:isConfidential="none" cppa:isAuthenticated="none" cppa:isTamperProof="none" cppa:isAuthorizationRequired="false" cppa:isIntelligibleCheckRequired="false" cppa:timeToPerform="P180M"/>
+                        <cppa:ChannelId>NAV_SyncHttpChannelB1</cppa:ChannelId>
+                    </cppa:ThisPartyActionBinding>
+                    <cppa:OtherPartyActionBinding>Partner_EgenandelFritak_Avvisning2</cppa:OtherPartyActionBinding>
+                </cppa:CanSend>
+                <cppa:CanReceive>
+                    <cppa:ThisPartyActionBinding cppa:id="NAV_EgenandelFritak_EgenandelForesporsel" cppa:action="EgenandelForesporsel" cppa:packageId="NAV_package_egenandelforesporsel_v1p0" ns3:type="simple">
+                        <cppa:BusinessTransactionCharacteristics cppa:isNonRepudiationRequired="true" cppa:isNonRepudiationReceiptRequired="true" cppa:isConfidential="none" cppa:isAuthenticated="none" cppa:isTamperProof="none" cppa:isAuthorizationRequired="false" cppa:isIntelligibleCheckRequired="false" cppa:timeToPerform="P180M"/>
+                        <cppa:ChannelId>NAV_SyncHttpChannelB1</cppa:ChannelId>
+                    </cppa:ThisPartyActionBinding>
+                    <cppa:OtherPartyActionBinding>Partner_EgenandelFritak_EgenandelForesporsel0</cppa:OtherPartyActionBinding>
+                </cppa:CanReceive>
+            </cppa:ServiceBinding>
+        </cppa:CollaborationRole>
+        <cppa:Certificate cppa:certId="NAV_default_sign_cert">
+            <ds:KeyInfo>
+<ds:X509Data>
+                    <ds:X509Certificate>MIIGTTCCBDWgAwIBAgILAZUvNM8SwtVyPLQwDQYJKoZIhvcNAQELBQAwbjELMAkGA1UEBhMCTk8xGDAWBgNVBGEMD05UUk5PLTk4MzE2MzMyNzETMBEGA1UECgwKQnV5cGFzcyBBUzEwMC4GA1UEAwwnQnV5cGFzcyBDbGFzcyAzIFRlc3Q0IENBIEcyIFNUIEJ1c2luZXNzMB4XDTIyMDkwNzEzMTQwNloXDTI1MDkwNzIxNTkwMFowcTELMAkGA1UEBhMCTk8xIzAhBgNVBAoMGkFSQkVJRFMtIE9HIFZFTEZFUkRTRVRBVEVOMSMwIQYDVQQDDBpBUkJFSURTLSBPRyBWRUxGRVJEU0VUQVRFTjEYMBYGA1UEYQwPTlRSTk8tODg5NjQwNzgyMIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEArd4kC/HGsTwNcI81y1+oGE8+P0I4/sF6hi26lvKhzBvnGijdWpnYKgnUQ+p1Z64GvHH2TLbdVJrLZ6p/AG/4VIe3KfBAPTWygpbwQcoN3PE6Wss0VFhoH0gzlCk/QZo5M3H/RaVkVj9UL+SyoZ7MyHOFlmb3lek9rUaSpa/gpViwgfkN0qNYdFNNk3rRLMMRhI84ukm/bC50fa63F/2lVjMlvL/T+DLEPJco3Bw67WxJMHlWmz6l9D64rcbipIAiddetuS2dJ+Q2GIYaWrNTJ68b+XbjU3+05VVNZ+xBlZsCQDZl8ie1hDo4uIpikjqMjFqqj6d/x5STFLdWbajOP5/wCYjGpfJo0ompnrfag9H8g+d0Vq+TsDILlmQHNjPTcRTjbPwo3I2+bg5ZlcO/wQaf7Gpu5GQ84TTIdOPJNH0pVR0DF+xltpR+L2nXhgypB718a2a70oIhgxoQDMHeWTk5/nmrUoEblUh0r4Y7IycS3GVHc1V7TihGCS4FIO6lAgMBAAGjggFnMIIBYzAJBgNVHRMEAjAAMB8GA1UdIwQYMBaAFKf+u2xZiK10LkZeemj50bu/z7aLMB0GA1UdDgQWBBSPEdwLai4XZ/Hzw8HCTiTBgwZs+TAOBgNVHQ8BAf8EBAMCBkAwHwYDVR0gBBgwFjAKBghghEIBGgEDAjAIBgYEAI96AQEwQQYDVR0fBDowODA2oDSgMoYwaHR0cDovL2NybC50ZXN0NC5idXlwYXNzY2EuY29tL0JQQ2wzQ2FHMlNUQlMuY3JsMHsGCCsGAQUFBwEBBG8wbTAtBggrBgEFBQcwAYYhaHR0cDovL29jc3Bicy50ZXN0NC5idXlwYXNzY2EuY29tMDwGCCsGAQUFBzAChjBodHRwOi8vY3J0LnRlc3Q0LmJ1eXBhc3NjYS5jb20vQlBDbDNDYUcyU1RCUy5jZXIwJQYIKwYBBQUHAQMEGTAXMBUGCCsGAQUFBwsCMAkGBwQAi+xJAQIwDQYJKoZIhvcNAQELBQADggIBAH3fTsd2KbAHRAvWqTw7qj350kwQ/MDeZqxGy0Eu+wQXDoWpT15MxMxGO+oCX8LoYlEtD/CYzq+Fq4Hclr4cWlZ+5eW/q14F9450+Hajmchw0CJZ3+ZPnB53HT2SftaH8jQjNPgAnDGfNXIW/WjGAlxRvBqCKE5Vt0xdCmQIs+iye/WwQjqiz+BAi4LpiB9Y6tQfZYcKfe8flAoeSMX8EBU6UtuhYNidTtGAYQLLJu4jzXjJ85KV9Z5enk6VuiyfRAS8XIzvBNM+MGXOe6htqHdu9XFdUtottoJdaU78uOWhHp9aUkdWDlfATPBWoCghrcpFPQuyN35vV+aPjH1Bf3eXlze1oDZ4qM0JcyuoEsfn1hkvee+bwGC2I/XdZZG8/y5+NuDCq7S9SDHnHYpFHJq9gBHrzmIXDIXVUGLHC27bkGTftsbq4nTxTZgTKXpmBfVajRrCSL0IU19HXsPakW5jtrGGU3jH5qTjZ9FnUyDsYZczwzA0C3ZQwPDvL2tT+a03yhJtvh/dgmDU8J+mhirQK0KLMzZ8Xh/Nm0PUUD8lt6cg0WP/9JB+8QoNeCmI90iicqjzLpzBmrRVHRWtnrg6g7aBxYDcehtBmlAyR2vp5URKuVHXxWUBxBs4HEv14mPnxFzIXfAreeC+07sMHpEacAYw0tZ96/POyRm6o30M</ds:X509Certificate>
+                </ds:X509Data>
+            </ds:KeyInfo>
+        </cppa:Certificate>
+        <cppa:Certificate cppa:certId="NAV_default_crypt_cert">
+            <ds:KeyInfo>
+<ds:X509Data>
+                    <ds:X509Certificate>MIIGTTCCBDWgAwIBAgILAZUu998EpC5cTMkwDQYJKoZIhvcNAQELBQAwbjELMAkGA1UEBhMCTk8xGDAWBgNVBGEMD05UUk5PLTk4MzE2MzMyNzETMBEGA1UECgwKQnV5cGFzcyBBUzEwMC4GA1UEAwwnQnV5cGFzcyBDbGFzcyAzIFRlc3Q0IENBIEcyIFNUIEJ1c2luZXNzMB4XDTIyMDkwNzEzMTQwNloXDTI1MDkwNzIxNTkwMFowcTELMAkGA1UEBhMCTk8xIzAhBgNVBAoMGkFSQkVJRFMtIE9HIFZFTEZFUkRTRVRBVEVOMSMwIQYDVQQDDBpBUkJFSURTLSBPRyBWRUxGRVJEU0VUQVRFTjEYMBYGA1UEYQwPTlRSTk8tODg5NjQwNzgyMIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEAwzkN8TyAJknEN8f3HHU4oiVTdaNyaiXOqzPprkfK0SI6DIW6h4j87PZkcp8qGnDEVBF37BP4l8/1HOh9ONeXSFjQCqKOyxkvpQgLiQDZjZ9Rn/Ss5/+tJ/yp8FOQzQer3d1zaKrTR5iqt1Q/qWNa0JVzcDlUpUE7r9jTsjIEuV0MN3gMS98n25ROp7E2hcJtNAdHN+gFcUMgYcSvWqDuqXDtCbXNPs2X6xLlvcI8UqrAP4HUkE+bMN8krVKV9gak0Gv7L6NpmsHdyetI7GPBBR1f//ik4RaFCC+e6AvTdaHGAwuRzsT5/xvB7bOzSIuX6jDxodImQ/nnZN7a5F7CRkQ9OzNs/hCXq5+yy3HvrXrhrz6WHiepO1sPZceD2+nfRBJbQSVn/DDfEWjX3xK7mvruijbIr2C4II9EgK1xQdpKvMfA2rJ1uvE6XxmvrTpXiTm9xEybu2gzBCllYHkDosQZh5fU0LeqIZ+H0n9zu8+J8xUJ+OTlPEkDpr2aSbOpAgMBAAGjggFnMIIBYzAJBgNVHRMEAjAAMB8GA1UdIwQYMBaAFKf+u2xZiK10LkZeemj50bu/z7aLMB0GA1UdDgQWBBQ0AyC2TGEEX1XNUf12iQVKMdEh6DAOBgNVHQ8BAf8EBAMCBaAwHwYDVR0gBBgwFjAKBghghEIBGgEDAjAIBgYEAI96AQEwQQYDVR0fBDowODA2oDSgMoYwaHR0cDovL2NybC50ZXN0NC5idXlwYXNzY2EuY29tL0JQQ2wzQ2FHMlNUQlMuY3JsMHsGCCsGAQUFBwEBBG8wbTAtBggrBgEFBQcwAYYhaHR0cDovL29jc3Bicy50ZXN0NC5idXlwYXNzY2EuY29tMDwGCCsGAQUFBzAChjBodHRwOi8vY3J0LnRlc3Q0LmJ1eXBhc3NjYS5jb20vQlBDbDNDYUcyU1RCUy5jZXIwJQYIKwYBBQUHAQMEGTAXMBUGCCsGAQUFBwsCMAkGBwQAi+xJAQIwDQYJKoZIhvcNAQELBQADggIBAJhhEltDJ5j3ZfLWJ19TPAN8ib1/FnHqoJALwj+y7LvhahDb63HlCdByg6T8evs071uSPsVI+zA7Lotj3+F6Y3yvCuB7vDOINCfm3NyyMicKboKpxmEDYkU+otjSCrlabaZLfHXuyQkI1KAr24La8kntd02O2R2hUef9K36nH/wvS+im3S+ZntYbFpO4X5e8LnOn1w0UgDOrE3Oesf9B3g3eChs3KHiBXfhzMI3o4StYm8Pg1pBE8Hmo9/7XWZ2dreI1ztLuDiGYr9OFnc7VUX+26zokxnJEY33On9wLyBOqBHpOxGWzL19UsZocDjAUoN8gJD3PCSA2jxe/cNLfjql1Z4iSxGD7w0KG8VxVc6M3q/rzV9/lEUu7JdwNaek62dfWA6h9068h35ROS0wtrSw6ZPxTaWgH+w3TNg7VJYMolSaUSNWMeokzGsP3D3xgZDnp9jV+M4UKp6z+LsnNe6adBRdU6AVciXhOQ1vls/P5igymQfmL2CeIIhh9V7nFUFgYbCFwuRrSeePc5lU2yx2mk3wtaWVVQVrzfIX5u7Mk26hptX8KUYJb/LEDR6bbFCxaapaZl4Zr5E80aUIAxZD3aVWMW4kaBdOqAzOFDEMx8zJPosfjfUK2V4hUrdcWnCwT6RHszPZ2r0tzp0lp76sTE88ft8+vyefGddiyWTEn</ds:X509Certificate>
+                </ds:X509Data>
+            </ds:KeyInfo>
+        </cppa:Certificate>
+        <cppa:SecurityDetails cppa:securityId="NAV_trustAnchorsAndPolicy"/>
+        <cppa:DeliveryChannel cppa:channelId="NAV_asyncSMTPChannelA2" cppa:transportId="NAV_transportSMTP_eresept" cppa:docExchangeId="NAV_docexchange_smtp_eresept">
+            <cppa:MessagingCharacteristics cppa:syncReplyMode="none" cppa:ackRequested="always" cppa:ackSignatureRequested="always" cppa:duplicateElimination="always"/>
+        </cppa:DeliveryChannel>
+        <cppa:DeliveryChannel cppa:channelId="NAV_SyncHttpChannelB1" cppa:transportId="NAV_transportHttp" cppa:docExchangeId="NAV_docexchange_http">
+            <cppa:MessagingCharacteristics cppa:syncReplyMode="signalsAndResponse" cppa:ackRequested="never" cppa:ackSignatureRequested="never" cppa:duplicateElimination="never"/>
+        </cppa:DeliveryChannel>
+        <cppa:Transport cppa:transportId="NAV_transportSMTP_eresept">
+            <cppa:TransportSender>
+                <cppa:TransportProtocol cppa:version="1.1">SMTP</cppa:TransportProtocol>
+            </cppa:TransportSender>
+            <cppa:TransportReceiver>
+                <cppa:TransportProtocol cppa:version="1.1">SMTP</cppa:TransportProtocol>
+                <cppa:Endpoint cppa:uri="mailto://mottak-qass@test-es.nav.no" cppa:type="allPurpose"/>
+            </cppa:TransportReceiver>
+        </cppa:Transport>
+        <cppa:Transport cppa:transportId="NAV_transportHttp">
+            <cppa:TransportSender>
+                <cppa:TransportProtocol cppa:version="1.1">HTTP</cppa:TransportProtocol>
+                <cppa:TransportClientSecurity>
+                    <cppa:TransportSecurityProtocol cppa:version="3.0">SSL</cppa:TransportSecurityProtocol>
+                </cppa:TransportClientSecurity>
+            </cppa:TransportSender>
+            <cppa:TransportReceiver>
+                <cppa:TransportProtocol cppa:version="1.1">HTTP</cppa:TransportProtocol>
+                <cppa:Endpoint cppa:uri="https://nhn-gw-q.nav.no:9443/ebxml/msh" cppa:type="allPurpose"/>
+                <cppa:TransportServerSecurity>
+                    <cppa:TransportSecurityProtocol cppa:version="3.0">SSL</cppa:TransportSecurityProtocol>
+                    <cppa:ServerCertificateRef cppa:certId="NAV_default_crypt_cert"/>
+                </cppa:TransportServerSecurity>
+            </cppa:TransportReceiver>
+        </cppa:Transport>
+        <cppa:DocExchange cppa:docExchangeId="NAV_docexchange_smtp_eresept">
+            <cppa:ebXMLSenderBinding cppa:version="2.0">
+                <cppa:ReliableMessaging>
+                    <cppa:Retries>4</cppa:Retries>
+                    <cppa:RetryInterval>PT240M</cppa:RetryInterval>
+                    <cppa:MessageOrderSemantics>NotGuaranteed</cppa:MessageOrderSemantics>
+                </cppa:ReliableMessaging>
+                <cppa:PersistDuration>P2D</cppa:PersistDuration>
+                <cppa:SenderNonRepudiation>
+                    <cppa:NonRepudiationProtocol cppa:version="string">http://www.w3.org/2000/09/xmldsig#</cppa:NonRepudiationProtocol>
+                    <cppa:HashFunction>http://www.w3.org/2001/04/xmlenc#sha256</cppa:HashFunction>
+                    <cppa:SignatureAlgorithm cppa:oid="1.2.840.113549.1.1.5" cppa:w3c="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256">http://www.w3.org/2001/04/xmldsig-more#rsa-sha256</cppa:SignatureAlgorithm>
+                    <cppa:SigningCertificateRef cppa:certId="NAV_default_sign_cert"/>
+                </cppa:SenderNonRepudiation>
+            </cppa:ebXMLSenderBinding>
+            <cppa:ebXMLReceiverBinding cppa:version="2.0">
+                <cppa:ReliableMessaging>
+                    <cppa:Retries>4</cppa:Retries>
+                    <cppa:RetryInterval>PT240M</cppa:RetryInterval>
+                    <cppa:MessageOrderSemantics>NotGuaranteed</cppa:MessageOrderSemantics>
+                </cppa:ReliableMessaging>
+                <cppa:PersistDuration>P2D</cppa:PersistDuration>
+                <cppa:ReceiverNonRepudiation>
+                    <cppa:NonRepudiationProtocol cppa:version="string">http://www.w3.org/2000/09/xmldsig#</cppa:NonRepudiationProtocol>
+                    <cppa:HashFunction>http://www.w3.org/2001/04/xmlenc#sha256</cppa:HashFunction>
+                    <cppa:SignatureAlgorithm cppa:oid="1.2.840.113549.1.1.5" cppa:w3c="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256">http://www.w3.org/2001/04/xmldsig-more#rsa-sha256</cppa:SignatureAlgorithm>
+                </cppa:ReceiverNonRepudiation>
+            </cppa:ebXMLReceiverBinding>
+        </cppa:DocExchange>
+        <cppa:DocExchange cppa:docExchangeId="NAV_docexchange_http">
+            <cppa:ebXMLSenderBinding cppa:version="2.0">
+                <cppa:SenderNonRepudiation>
+                    <cppa:NonRepudiationProtocol>
+						http://www.w3.org/2000/09/xmldsig#
+					</cppa:NonRepudiationProtocol>
+                    <cppa:HashFunction>http://www.w3.org/2001/04/xmlenc#sha256</cppa:HashFunction>
+                    <cppa:SignatureAlgorithm cppa:oid="1.2.840.113549.1.1.5" cppa:w3c="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256">http://www.w3.org/2001/04/xmldsig-more#rsa-sha256</cppa:SignatureAlgorithm>
+                    <cppa:SigningCertificateRef cppa:certId="NAV_default_sign_cert"/>
+                </cppa:SenderNonRepudiation>
+            </cppa:ebXMLSenderBinding>
+            <cppa:ebXMLReceiverBinding cppa:version="2.0">
+                <cppa:ReceiverNonRepudiation>
+                    <cppa:NonRepudiationProtocol>http://www.w3.org/2000/09/xmldsig#</cppa:NonRepudiationProtocol>
+                    <cppa:HashFunction>http://www.w3.org/2001/04/xmlenc#sha256</cppa:HashFunction>
+                    <cppa:SignatureAlgorithm cppa:oid="1.2.840.113549.1.1.5" cppa:w3c="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256">http://www.w3.org/2001/04/xmldsig-more#rsa-sha256</cppa:SignatureAlgorithm>
+                </cppa:ReceiverNonRepudiation>
+            </cppa:ebXMLReceiverBinding>
+        </cppa:DocExchange>
+    </cppa:PartyInfo>
+    <cppa:SimplePart cppa:id="Partner_msg_header" cppa:mimetype="application/xml">
+        <cppa:NamespaceSupported cppa:location="msg-header-2_0.xsd" cppa:version="2.0">http://www.oasis-open.org/committees/ebxml-msg/schema</cppa:NamespaceSupported>
+    </cppa:SimplePart>
+    <cppa:SimplePart cppa:id="Partner_message_apprec_v1p0" cppa:mimetype="application/xml">
+        <cppa:NamespaceSupported cppa:location="AppRec-v1-2004-11-21.xsd" cppa:version="1.0">http://www.kith.no/xmlstds/apprec/2004-11-21</cppa:NamespaceSupported>
+    </cppa:SimplePart>
+    <cppa:SimplePart cppa:id="Partner_message_erm18_v2p5" cppa:mimetype="application/xml">
+        <cppa:NamespaceSupported cppa:location="MsgHead-v1_2.xsd" cppa:version="1.2">http://www.kith.no/xmlstds/msghead/2006-05-24</cppa:NamespaceSupported>
+        <cppa:NamespaceSupported cppa:location="ER-M18-2013-04-16.xsd" cppa:version="2.5">http://www.kith.no/xmlstds/eresept/m18/2013-04-16</cppa:NamespaceSupported>
+    </cppa:SimplePart>
+    <cppa:SimplePart cppa:id="Partner_message_erm22_v2p5" cppa:mimetype="application/xml">
+        <cppa:NamespaceSupported cppa:location="MsgHead-v1_2.xsd" cppa:version="1.2">http://www.kith.no/xmlstds/msghead/2006-05-24</cppa:NamespaceSupported>
+        <cppa:NamespaceSupported cppa:location="ER-M22-2006-10-06.xsd" cppa:version="2.5">http://www.kith.no/xmlstds/eresept/m22/2006-10-06</cppa:NamespaceSupported>
+    </cppa:SimplePart>
+    <cppa:SimplePart cppa:id="Partner_message_erm23_v2p5" cppa:mimetype="application/xml">
+        <cppa:NamespaceSupported cppa:location="MsgHead-v1_2.xsd" cppa:version="1.2">http://www.kith.no/xmlstds/msghead/2006-05-24</cppa:NamespaceSupported>
+        <cppa:NamespaceSupported cppa:location="ER-M23-2006-10-06.xsd" cppa:version="2.5">http://www.kith.no/xmlstds/eresept/m23/2006-10-06</cppa:NamespaceSupported>
+    </cppa:SimplePart>
+    <cppa:SimplePart cppa:id="Partner_message_egenandel_v1p0" cppa:mimetype="application/xml">
+        <cppa:NamespaceSupported cppa:location="MsgHead-v1_2.xsd" cppa:version="1.2">http://www.kith.no/xmlstds/msghead/2006-05-24</cppa:NamespaceSupported>
+        <cppa:NamespaceSupported cppa:location="NAV-Egenandel-2010-02-01.xsd" cppa:version="1.0">http://www.kith.no/xmlstds/nav/egenandel/2010-02-01</cppa:NamespaceSupported>
+    </cppa:SimplePart>
+    <cppa:SimplePart cppa:id="Partner_message_egenandelsvar_v1p0" cppa:mimetype="application/xml">
+        <cppa:NamespaceSupported cppa:location="MsgHead-v1_2.xsd" cppa:version="1.2">http://www.kith.no/xmlstds/msghead/2006-05-24</cppa:NamespaceSupported>
+        <cppa:NamespaceSupported cppa:location="NAV-Egenandel-2010-02-01.xsd" cppa:version="1.0">http://www.kith.no/xmlstds/nav/egenandel/2010-02-01</cppa:NamespaceSupported>
+    </cppa:SimplePart>
+    <cppa:SimplePart cppa:id="NAV_msg_header" cppa:mimetype="application/xml">
+        <cppa:NamespaceSupported cppa:location="msg-header-2_0.xsd" cppa:version="2.0">http://www.oasis-open.org/committees/ebxml-msg/schema</cppa:NamespaceSupported>
+    </cppa:SimplePart>
+    <cppa:SimplePart cppa:id="NAV_message_apprec_v1p0" cppa:mimetype="application/xml">
+        <cppa:NamespaceSupported cppa:location="AppRec-v1-2004-11-21.xsd" cppa:version="1.0">http://www.kith.no/xmlstds/apprec/2004-11-21</cppa:NamespaceSupported>
+    </cppa:SimplePart>
+    <cppa:SimplePart cppa:id="NAV_message_erm18_v2p5" cppa:mimetype="application/xml">
+        <cppa:NamespaceSupported cppa:location="MsgHead-v1_2.xsd" cppa:version="1.2">http://www.kith.no/xmlstds/msghead/2006-05-24</cppa:NamespaceSupported>
+        <cppa:NamespaceSupported cppa:location="ER-M18-2013-04-16.xsd" cppa:version="2.5">http://www.kith.no/xmlstds/eresept/m18/2013-04-16</cppa:NamespaceSupported>
+    </cppa:SimplePart>
+    <cppa:SimplePart cppa:id="NAV_message_erm22_v2p5" cppa:mimetype="application/xml">
+        <cppa:NamespaceSupported cppa:location="MsgHead-v1_2.xsd" cppa:version="1.2">http://www.kith.no/xmlstds/msghead/2006-05-24</cppa:NamespaceSupported>
+        <cppa:NamespaceSupported cppa:location="ER-M22-2006-10-06.xsd" cppa:version="2.5">http://www.kith.no/xmlstds/eresept/m22/2006-10-06</cppa:NamespaceSupported>
+    </cppa:SimplePart>
+    <cppa:SimplePart cppa:id="NAV_message_erm23_v2p5" cppa:mimetype="application/xml">
+        <cppa:NamespaceSupported cppa:location="MsgHead-v1_2.xsd" cppa:version="1.2">http://www.kith.no/xmlstds/msghead/2006-05-24</cppa:NamespaceSupported>
+        <cppa:NamespaceSupported cppa:location="ER-M23-2006-10-06.xsd" cppa:version="2.5">http://www.kith.no/xmlstds/eresept/m23/2006-10-06</cppa:NamespaceSupported>
+    </cppa:SimplePart>
+    <cppa:SimplePart cppa:id="NAV_message_egenandel_v1p0" cppa:mimetype="application/xml">
+        <cppa:NamespaceSupported cppa:location="MsgHead-v1_2.xsd" cppa:version="1.2">http://www.kith.no/xmlstds/msghead/2006-05-24</cppa:NamespaceSupported>
+        <cppa:NamespaceSupported cppa:location="NAV-Egenandel-2010-02-01.xsd" cppa:version="1.0">http://www.kith.no/xmlstds/nav/egenandel/2010-02-01</cppa:NamespaceSupported>
+    </cppa:SimplePart>
+    <cppa:SimplePart cppa:id="NAV_message_egenandelsvar_v1p0" cppa:mimetype="application/xml">
+        <cppa:NamespaceSupported cppa:location="MsgHead-v1_2.xsd" cppa:version="1.2">http://www.kith.no/xmlstds/msghead/2006-05-24</cppa:NamespaceSupported>
+        <cppa:NamespaceSupported cppa:location="NAV-Egenandel-2010-02-01.xsd" cppa:version="1.0">http://www.kith.no/xmlstds/nav/egenandel/2010-02-01</cppa:NamespaceSupported>
+    </cppa:SimplePart>
+    <cppa:Packaging cppa:id="Partner_package_mshsignal">
+        <cppa:ProcessingCapabilities cppa:parse="true" cppa:generate="true"/>
+        <cppa:CompositeList>
+            <cppa:Composite cppa:id="Partner_msh_signal" cppa:mimetype="multipart/related" cppa:mimeparameters="type=text/xml">
+                <cppa:Constituent cppa:idref="Partner_msg_header" cppa:excludedFromSignature="false"/>
+            </cppa:Composite>
+        </cppa:CompositeList>
+    </cppa:Packaging>
+    <cppa:Packaging cppa:id="Partner_package_apprec_v1p0">
+        <cppa:ProcessingCapabilities cppa:parse="true" cppa:generate="true"/>
+        <cppa:CompositeList>
+            <cppa:Encapsulation cppa:id="Partner_enc_apprec_v1p0" cppa:mimetype="application/pkcs7-mime" cppa:mimeparameters="smime-type=&quot;enveloped-data&quot;">
+                <cppa:Constituent cppa:idref="Partner_message_apprec_v1p0" cppa:excludedFromSignature="false"/>
+            </cppa:Encapsulation>
+            <cppa:Composite cppa:id="Partner_msg_apprec_v1p0" cppa:mimetype="multipart/related" cppa:mimeparameters="type=text/xml">
+                <cppa:Constituent cppa:idref="Partner_msg_header" cppa:excludedFromSignature="false"/>
+                <cppa:Constituent cppa:idref="Partner_enc_apprec_v1p0" cppa:excludedFromSignature="false"/>
+            </cppa:Composite>
+        </cppa:CompositeList>
+    </cppa:Packaging>
+    <cppa:Packaging cppa:id="Partner_package_oppgjorskrav_v2p5">
+        <cppa:ProcessingCapabilities cppa:parse="true" cppa:generate="true"/>
+        <cppa:CompositeList>
+            <cppa:Encapsulation cppa:id="Partner_zip_erm18_v2p5" cppa:mimetype="application/x-gzip" cppa:mimeparameters="type=application/x-gzip">
+                <cppa:Constituent cppa:idref="Partner_message_erm18_v2p5" cppa:excludedFromSignature="false"/>
+            </cppa:Encapsulation>
+            <cppa:Encapsulation cppa:id="Partner_enc_erm18_v2p5" cppa:mimetype="application/pkcs7-mime" cppa:mimeparameters="smime-type=&quot;enveloped-data&quot;">
+                <cppa:Constituent cppa:idref="Partner_zip_erm18_v2p5" cppa:excludedFromSignature="false"/>
+            </cppa:Encapsulation>
+            <cppa:Composite cppa:id="Partner_msg_erm18_v2p5" cppa:mimetype="multipart/related" cppa:mimeparameters="type=text/xml">
+                <cppa:Constituent cppa:idref="Partner_msg_header" cppa:excludedFromSignature="false"/>
+                <cppa:Constituent cppa:idref="Partner_enc_erm18_v2p5" cppa:excludedFromSignature="false"/>
+            </cppa:Composite>
+        </cppa:CompositeList>
+    </cppa:Packaging>
+    <cppa:Packaging cppa:id="Partner_package_oppgjorsresultat_v2p5">
+        <cppa:ProcessingCapabilities cppa:parse="true" cppa:generate="true"/>
+        <cppa:CompositeList>
+            <cppa:Encapsulation cppa:id="Partner_enc_erm22_v2p5" cppa:mimetype="application/pkcs7-mime" cppa:mimeparameters="smime-type=&quot;enveloped-data&quot;">
+                <cppa:Constituent cppa:idref="Partner_message_erm22_v2p5" cppa:excludedFromSignature="false"/>
+            </cppa:Encapsulation>
+            <cppa:Composite cppa:id="Partner_msg_erm22_v2p5" cppa:mimetype="multipart/related" cppa:mimeparameters="type=text/xml">
+                <cppa:Constituent cppa:idref="Partner_msg_header" cppa:excludedFromSignature="false"/>
+                <cppa:Constituent cppa:idref="Partner_enc_erm22_v2p5" cppa:excludedFromSignature="false"/>
+            </cppa:Composite>
+        </cppa:CompositeList>
+    </cppa:Packaging>
+    <cppa:Packaging cppa:id="Partner_package_utbetaling_v2p5">
+        <cppa:ProcessingCapabilities cppa:parse="true" cppa:generate="true"/>
+        <cppa:CompositeList>
+            <cppa:Encapsulation cppa:id="Partner_enc_erm23_v2p5" cppa:mimetype="application/pkcs7-mime" cppa:mimeparameters="smime-type=&quot;enveloped-data&quot;">
+                <cppa:Constituent cppa:idref="Partner_message_erm23_v2p5" cppa:excludedFromSignature="false"/>
+            </cppa:Encapsulation>
+            <cppa:Composite cppa:id="Partner_msg_erm23_v2p5" cppa:mimetype="multipart/related" cppa:mimeparameters="type=text/xml">
+                <cppa:Constituent cppa:idref="Partner_msg_header" cppa:excludedFromSignature="false"/>
+                <cppa:Constituent cppa:idref="Partner_enc_erm23_v2p5" cppa:excludedFromSignature="false"/>
+            </cppa:Composite>
+        </cppa:CompositeList>
+    </cppa:Packaging>
+    <cppa:Packaging cppa:id="Partner_package_egenandelforesporsel_v1p0">
+        <cppa:ProcessingCapabilities cppa:parse="true" cppa:generate="true"/>
+        <cppa:CompositeList>
+            <cppa:Encapsulation cppa:id="Partner_enc_egenandel_v1p0" cppa:mimetype="application/pkcs7-mime" cppa:mimeparameters="smime-type=&quot;enveloped-data&quot;">
+                <cppa:Constituent cppa:idref="Partner_message_egenandel_v1p0" cppa:excludedFromSignature="false"/>
+            </cppa:Encapsulation>
+            <cppa:Composite cppa:id="Partner_request_msg_egenandel_v1p0" cppa:mimetype="multipart/related" cppa:mimeparameters="type=text/xml">
+                <cppa:Constituent cppa:idref="Partner_msg_header" cppa:excludedFromSignature="false"/>
+                <cppa:Constituent cppa:idref="Partner_enc_egenandel_v1p0" cppa:excludedFromSignature="false"/>
+            </cppa:Composite>
+        </cppa:CompositeList>
+    </cppa:Packaging>
+    <cppa:Packaging cppa:id="Partner_package_egenandelsvar_v1p0">
+        <cppa:ProcessingCapabilities cppa:parse="true" cppa:generate="true"/>
+        <cppa:CompositeList>
+            <cppa:Encapsulation cppa:id="Partner_enc_egenandelsvar_v1p0" cppa:mimetype="application/pkcs7-mime" cppa:mimeparameters="smime-type=&quot;enveloped-data&quot;">
+                <cppa:Constituent cppa:idref="Partner_message_egenandelsvar_v1p0" cppa:excludedFromSignature="false"/>
+            </cppa:Encapsulation>
+            <cppa:Composite cppa:id="Partner_request_msg_egenandelsvar_v1p0" cppa:mimetype="multipart/related" cppa:mimeparameters="type=text/xml">
+                <cppa:Constituent cppa:idref="Partner_msg_header" cppa:excludedFromSignature="false"/>
+                <cppa:Constituent cppa:idref="Partner_enc_egenandelsvar_v1p0" cppa:excludedFromSignature="false"/>
+            </cppa:Composite>
+        </cppa:CompositeList>
+    </cppa:Packaging>
+    <cppa:Packaging cppa:id="NAV_package_mshsignal">
+        <cppa:ProcessingCapabilities cppa:parse="true" cppa:generate="true"/>
+        <cppa:CompositeList>
+            <cppa:Composite cppa:id="NAV_msh_signal" cppa:mimetype="multipart/related" cppa:mimeparameters="type=text/xml">
+                <cppa:Constituent cppa:idref="NAV_msg_header" cppa:excludedFromSignature="false"/>
+            </cppa:Composite>
+        </cppa:CompositeList>
+    </cppa:Packaging>
+    <cppa:Packaging cppa:id="NAV_package_apprec_v1p0">
+        <cppa:ProcessingCapabilities cppa:parse="true" cppa:generate="true"/>
+        <cppa:CompositeList>
+            <cppa:Encapsulation cppa:id="NAV_enc_apprec_v1p0" cppa:mimetype="application/pkcs7-mime" cppa:mimeparameters="smime-type=&quot;enveloped-data&quot;">
+                <cppa:Constituent cppa:idref="NAV_message_apprec_v1p0" cppa:excludedFromSignature="false"/>
+            </cppa:Encapsulation>
+            <cppa:Composite cppa:id="NAV_msg_apprec_v1p0" cppa:mimetype="multipart/related" cppa:mimeparameters="type=text/xml">
+                <cppa:Constituent cppa:idref="NAV_msg_header" cppa:excludedFromSignature="false"/>
+                <cppa:Constituent cppa:idref="NAV_enc_apprec_v1p0" cppa:excludedFromSignature="false"/>
+            </cppa:Composite>
+        </cppa:CompositeList>
+    </cppa:Packaging>
+    <cppa:Packaging cppa:id="NAV_package_oppgjorskrav_v2p5">
+        <cppa:ProcessingCapabilities cppa:parse="true" cppa:generate="true"/>
+        <cppa:CompositeList>
+            <cppa:Encapsulation cppa:id="NAV_zip_erm18_v2p5" cppa:mimetype="application/x-gzip" cppa:mimeparameters="type=application/x-gzip">
+                <cppa:Constituent cppa:idref="NAV_message_erm18_v2p5" cppa:excludedFromSignature="false"/>
+            </cppa:Encapsulation>
+            <cppa:Encapsulation cppa:id="NAV_enc_erm18_v2p5" cppa:mimetype="application/pkcs7-mime" cppa:mimeparameters="smime-type=&quot;enveloped-data&quot;">
+                <cppa:Constituent cppa:idref="NAV_zip_erm18_v2p5" cppa:excludedFromSignature="false"/>
+            </cppa:Encapsulation>
+            <cppa:Composite cppa:id="NAV_msg_erm18_v2p5" cppa:mimetype="multipart/related" cppa:mimeparameters="type=text/xml">
+                <cppa:Constituent cppa:idref="NAV_msg_header" cppa:excludedFromSignature="false"/>
+                <cppa:Constituent cppa:idref="NAV_enc_erm18_v2p5" cppa:excludedFromSignature="false"/>
+            </cppa:Composite>
+        </cppa:CompositeList>
+    </cppa:Packaging>
+    <cppa:Packaging cppa:id="NAV_package_oppgjorsresultat_v2p5">
+        <cppa:ProcessingCapabilities cppa:parse="true" cppa:generate="true"/>
+        <cppa:CompositeList>
+            <cppa:Encapsulation cppa:id="NAV_enc_erm22_v2p5" cppa:mimetype="application/pkcs7-mime" cppa:mimeparameters="smime-type=&quot;enveloped-data&quot;">
+                <cppa:Constituent cppa:idref="NAV_message_erm22_v2p5" cppa:excludedFromSignature="false"/>
+            </cppa:Encapsulation>
+            <cppa:Composite cppa:id="NAV_msg_erm22_v2p5" cppa:mimetype="multipart/related" cppa:mimeparameters="type=text/xml">
+                <cppa:Constituent cppa:idref="NAV_msg_header" cppa:excludedFromSignature="false"/>
+                <cppa:Constituent cppa:idref="NAV_enc_erm22_v2p5" cppa:excludedFromSignature="false"/>
+            </cppa:Composite>
+        </cppa:CompositeList>
+    </cppa:Packaging>
+    <cppa:Packaging cppa:id="NAV_package_utbetaling_v2p5">
+        <cppa:ProcessingCapabilities cppa:parse="true" cppa:generate="true"/>
+        <cppa:CompositeList>
+            <cppa:Encapsulation cppa:id="NAV_enc_erm23_v2p5" cppa:mimetype="application/pkcs7-mime" cppa:mimeparameters="smime-type=&quot;enveloped-data&quot;">
+                <cppa:Constituent cppa:idref="NAV_message_erm23_v2p5" cppa:excludedFromSignature="false"/>
+            </cppa:Encapsulation>
+            <cppa:Composite cppa:id="NAV_msg_erm23_v2p5" cppa:mimetype="multipart/related" cppa:mimeparameters="type=text/xml">
+                <cppa:Constituent cppa:idref="NAV_msg_header" cppa:excludedFromSignature="false"/>
+                <cppa:Constituent cppa:idref="NAV_enc_erm23_v2p5" cppa:excludedFromSignature="false"/>
+            </cppa:Composite>
+        </cppa:CompositeList>
+    </cppa:Packaging>
+    <cppa:Packaging cppa:id="NAV_package_egenandelforesporsel_v1p0">
+        <cppa:ProcessingCapabilities cppa:parse="true" cppa:generate="true"/>
+        <cppa:CompositeList>
+            <cppa:Encapsulation cppa:id="NAV_enc_egenandel_v1p0" cppa:mimetype="application/pkcs7-mime" cppa:mimeparameters="smime-type=&quot;enveloped-data&quot;">
+                <cppa:Constituent cppa:idref="NAV_message_egenandel_v1p0" cppa:excludedFromSignature="false"/>
+            </cppa:Encapsulation>
+            <cppa:Composite cppa:id="NAV_request_msg_egenandel_v1p0" cppa:mimetype="multipart/related" cppa:mimeparameters="type=text/xml">
+                <cppa:Constituent cppa:idref="NAV_msg_header" cppa:excludedFromSignature="false"/>
+                <cppa:Constituent cppa:idref="NAV_enc_egenandel_v1p0" cppa:excludedFromSignature="false"/>
+            </cppa:Composite>
+        </cppa:CompositeList>
+    </cppa:Packaging>
+    <cppa:Packaging cppa:id="NAV_package_egenandelsvar_v1p0">
+        <cppa:ProcessingCapabilities cppa:parse="true" cppa:generate="true"/>
+        <cppa:CompositeList>
+            <cppa:Encapsulation cppa:id="NAV_enc_egenandelsvar_v1p0" cppa:mimetype="application/pkcs7-mime" cppa:mimeparameters="smime-type=&quot;enveloped-data&quot;">
+                <cppa:Constituent cppa:idref="NAV_message_egenandelsvar_v1p0" cppa:excludedFromSignature="false"/>
+            </cppa:Encapsulation>
+            <cppa:Composite cppa:id="NAV_request_msg_egenandelsvar_v1p0" cppa:mimetype="multipart/related" cppa:mimeparameters="type=text/xml">
+                <cppa:Constituent cppa:idref="NAV_msg_header" cppa:excludedFromSignature="false"/>
+                <cppa:Constituent cppa:idref="NAV_enc_egenandelsvar_v1p0" cppa:excludedFromSignature="false"/>
+            </cppa:Composite>
+        </cppa:CompositeList>
+    </cppa:Packaging>
+    <cppa:Signature>
+        <ds:Signature>
+            <ds:SignedInfo>
+                <ds:CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>
+                <ds:SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
+                <ds:Reference URI="">
+                    <ds:Transforms>
+                        <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+                        <ds:Transform Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>
+                    </ds:Transforms>
+                    <ds:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+                    <ds:DigestValue></ds:DigestValue>
+                </ds:Reference>
+            </ds:SignedInfo>
+            <ds:SignatureValue/>
+        </ds:Signature>
+    </cppa:Signature>
+</cppa:CollaborationProtocolAgreement>


### PR DESCRIPTION
Includes same functionality except:
 - Reads CPA ID from file content, not from filename.
 - When finding duplicate CPA IDs from NFS, throw exception and cancel sync.
 - Skips upsert if DB entry is newer than NFS entry.