### PR TITLE
noe midlertidig fix så at vi kan bruke cpaId med Frikort teamet for t…

### DIFF
--- a/ebms-provider/src/main/kotlin/no/nav/emottak/ebms/sendin/SendInService.kt
+++ b/ebms-provider/src/main/kotlin/no/nav/emottak/ebms/sendin/SendInService.kt
@@ -17,6 +17,7 @@ class SendInService(val httpClient: SendInClient) {
             payloadMessage.payload.contentId,
             payloadMessage.payload.bytes,
             payloadMessage.addressing,
+            payloadMessage.cpaId,
             EbmsProcessing()
         )
         return withContext(Dispatchers.IO) {

--- a/ebms-send-in/src/main/kotlin/no/nav/emottak/fellesformat/FellesFormatWrapper.kt
+++ b/ebms-send-in/src/main/kotlin/no/nav/emottak/fellesformat/FellesFormatWrapper.kt
@@ -28,7 +28,7 @@ fun EIFellesformat.addressing(toParty: Party): Addressing {
 
 fun wrapMessageInEIFellesFormat(sendInRequest: SendInRequest): EIFellesformat =
     fellesFormatFactory.createEIFellesformat().also {
-        it.mottakenhetBlokk = createFellesFormatMottakEnhetBlokk(sendInRequest.messageId, sendInRequest.conversationId, sendInRequest.addressing)
+        it.mottakenhetBlokk = createFellesFormatMottakEnhetBlokk(sendInRequest)
         it.msgHead = unmarshal(sendInRequest.payload.toString(Charsets.UTF_8), MsgHead::class.java)
     }.also {
         if (getEnvVar("NAIS_CLUSTER_NAME", "local") != "prod-fss") {
@@ -36,15 +36,15 @@ fun wrapMessageInEIFellesFormat(sendInRequest: SendInRequest): EIFellesformat =
         }
     }
 
-private fun createFellesFormatMottakEnhetBlokk(mottaksId: String, conversationId: String, addressing: Addressing): EIFellesformat.MottakenhetBlokk =
+private fun createFellesFormatMottakEnhetBlokk(sendInRequest: SendInRequest): EIFellesformat.MottakenhetBlokk =
     fellesFormatFactory.createEIFellesformatMottakenhetBlokk().also {
-        it.ebXMLSamtaleId = conversationId
-        it.ebAction = addressing.action
-        it.ebService = addressing.service
-        it.ebRole = addressing.from.role
+        it.ebXMLSamtaleId = sendInRequest.conversationId
+        it.ebAction = sendInRequest.addressing.action
+        it.ebService = sendInRequest.addressing.service
+        it.ebRole = sendInRequest.addressing.from.role
         it.avsender = "TODO"
         it.avsenderRef = "TODO"
-        it.mottaksId = mottaksId
+        it.mottaksId = sendInRequest.messageId
         it.mottattDatotid = Instant.now().toXMLGregorianCalendar()
         it.ediLoggId = "TODO"
         it.avsenderFnrFraDigSignatur = "TODO"
@@ -52,5 +52,5 @@ private fun createFellesFormatMottakEnhetBlokk(mottaksId: String, conversationId
         it.herIdentifikator = "TODO"
         it.orgNummer = "TODO"
         it.meldingsType = "TODO"
-        it.partnerReferanse = "TODO"
+        it.partnerReferanse = sendInRequest.cpaId
     }

--- a/ebms-send-in/src/test/kotlin/InntektsforesporselTest.kt
+++ b/ebms-send-in/src/test/kotlin/InntektsforesporselTest.kt
@@ -51,6 +51,7 @@ class InntektsforesporselTest {
                     "Inntektsforesporsel",
                     "Inntektsforesporsel"
                 ),
+                "dummycpa",
                 EbmsProcessing()
             ),
             finnUtbetalingListeFeil

--- a/ebms-send-in/src/test/kotlin/no/nav/emottak/fellesformat/FellesFormatWrapperTest.kt
+++ b/ebms-send-in/src/test/kotlin/no/nav/emottak/fellesformat/FellesFormatWrapperTest.kt
@@ -7,6 +7,7 @@ import no.nav.emottak.melding.model.EbmsProcessing
 import no.nav.emottak.melding.model.Party
 import no.nav.emottak.melding.model.PartyId
 import no.nav.emottak.melding.model.SendInRequest
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
 class FellesFormatWrapperTest {
@@ -21,9 +22,11 @@ class FellesFormatWrapperTest {
             payloadId = "123",
             addressing = createAddressing(),
             ebmsProcessing = EbmsProcessing(),
+            cpaId = "dummyCpa",
             payload = processedPayload
         )
         val fellesFormat = wrapMessageInEIFellesFormat(sendInRequest)
+        Assertions.assertEquals(fellesFormat.mottakenhetBlokk.partnerReferanse, sendInRequest.cpaId)
         log.info(marshal(fellesFormat))
     }
 }

--- a/felles/src/main/kotlin/no/nav/emottak/melding/model/Payload.kt
+++ b/felles/src/main/kotlin/no/nav/emottak/melding/model/Payload.kt
@@ -14,6 +14,7 @@ data class SendInRequest(
     val payloadId: String,
     val payload: ByteArray,
     val addressing: Addressing,
+    val cpaId:String,
     val ebmsProcessing: EbmsProcessing
 )
 


### PR DESCRIPTION
Potensielt midlertidig fiks å få et slags tracing mellom requestene som treffer oss og requestene som treffer Frikort teamet. Partnerreferanse representerer CPA-en som er valid. Så CPA-en som vi bruker og er allerede verifisert via Validate endepunkten bør vare bra nok.