### PR TITLE
Use NAIS auto-instrumentation for telemetry with multiple destinations

### DIFF
--- a/.nais/cpa-repo-dev.yaml
+++ b/.nais/cpa-repo-dev.yaml
@@ -16,6 +16,17 @@ spec:
     initialDelay: 30
     timeout: 10
     failureThreshold: 10
+  observability:
+    autoInstrumentation:
+      enabled: true
+      runtime: java
+      destinations:
+        - id: "grafana-lgtm"
+        - id: "elastic-apm"
+    logging:
+      destinations:
+        - id: loki
+        - id: elastic
   readiness:
     path: "/internal/health/readiness"
     port: 8080

--- a/.nais/cpa-repo-prod.yaml
+++ b/.nais/cpa-repo-prod.yaml
@@ -16,6 +16,17 @@ spec:
     initialDelay: 30
     timeout: 10
     failureThreshold: 10
+  observability:
+    autoInstrumentation:
+      enabled: true
+      runtime: java
+      destinations:
+        - id: "grafana-lgtm"
+        - id: "elastic-apm"
+    logging:
+      destinations:
+        - id: loki
+        - id: elastic
   readiness:
     path: "/internal/health/readiness"
     port: 8080

--- a/.nais/ebms-payload-dev.yaml
+++ b/.nais/ebms-payload-dev.yaml
@@ -16,6 +16,17 @@ spec:
     initialDelay: 30
     timeout: 10
     failureThreshold: 10
+  observability:
+    autoInstrumentation:
+      enabled: true
+      runtime: java
+      destinations:
+        - id: "grafana-lgtm"
+        - id: "elastic-apm"
+    logging:
+      destinations:
+        - id: loki
+        - id: elastic
   readiness:
     path: "/internal/health/readiness"
     port: 8080
@@ -58,5 +69,3 @@ spec:
       value: DEBUG
     - name: TRUSTSTORE_PATH
       value: truststore_test.p12
-  
-      

--- a/.nais/ebms-payload-prod.yaml
+++ b/.nais/ebms-payload-prod.yaml
@@ -16,6 +16,17 @@ spec:
     initialDelay: 30
     timeout: 10
     failureThreshold: 10
+  observability:
+    autoInstrumentation:
+      enabled: true
+      runtime: java
+      destinations:
+        - id: "grafana-lgtm"
+        - id: "elastic-apm"
+    logging:
+      destinations:
+        - id: loki
+        - id: elastic
   readiness:
     path: "/internal/health/readiness"
     port: 8080

--- a/.nais/ebms-provider-dev.yaml
+++ b/.nais/ebms-provider-dev.yaml
@@ -17,6 +17,17 @@ spec:
     initialDelay: 30
     timeout: 10
     failureThreshold: 10
+  observability:
+    autoInstrumentation:
+      enabled: true
+      runtime: java
+      destinations:
+        - id: "grafana-lgtm"
+        - id: "elastic-apm"
+    logging:
+      destinations:
+        - id: loki
+        - id: elastic
   readiness:
     path: "/internal/health/readiness"
     port: 8080

--- a/.nais/ebms-provider-prod.yaml
+++ b/.nais/ebms-provider-prod.yaml
@@ -17,6 +17,17 @@ spec:
     initialDelay: 30
     timeout: 10
     failureThreshold: 10
+  observability:
+    autoInstrumentation:
+      enabled: true
+      runtime: java
+      destinations:
+        - id: "grafana-lgtm"
+        - id: "elastic-apm"
+    logging:
+      destinations:
+        - id: loki
+        - id: elastic
   readiness:
     path: "/internal/health/readiness"
     port: 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/navikt/baseimages/temurin:21-appdynamics
+FROM ghcr.io/navikt/baseimages/temurin:21
 COPY init/init.s[h] /init-scripts/
 COPY build/libs/app.jar ./
 


### PR DESCRIPTION
Adds new destinations: Tempo and Loki for future development. Auto-instrumentation replaces AppDynamics which is getting depracated end of 2024.