### PR TITLE
fix: when payload response contains error, we throw EbmsException

### DIFF
--- a/ebms-provider/src/main/kotlin/no/nav/emottak/ebms/processing/ProcessingService.kt
+++ b/ebms-provider/src/main/kotlin/no/nav/emottak/ebms/processing/ProcessingService.kt
@@ -37,10 +37,16 @@ class ProcessingService(private val httpClient: PayloadProcessingClient) {
                 addressing = addressing,
                 payload = payloadMessage.payload
             )
+            val payloadResponse = httpClient.postPayloadRequest(payloadRequest)
+
+            if (payloadResponse.error != null) {
+                throw EbmsException("Payload Processing has failed: ${payloadResponse.error}")
+            }
+
             Pair(
                 payloadMessage.copy(
                     payload = withContext(Dispatchers.IO) {
-                        httpClient.postPayloadRequest(payloadRequest).processedPayload!!
+                        payloadResponse.processedPayload!!
                     }
                 ),
                 direction

--- a/ebms-provider/src/main/kotlin/no/nav/emottak/ebms/validation/DokumentValidator.kt
+++ b/ebms-provider/src/main/kotlin/no/nav/emottak/ebms/validation/DokumentValidator.kt
@@ -23,7 +23,7 @@ class DokumentValidator(val httpClient: CpaRepoClient) {
     suspend fun validateIn(message: EbmsMessage) = validate(IN, message, true)
     suspend fun validateOut(message: EbmsMessage) = validate(OUT, message, false)
 
-    private suspend fun validate(direction: Direction, message: EbmsMessage, sjekSignature: Boolean): ValidationResult {
+    private suspend fun validate(direction: Direction, message: EbmsMessage, checkSignature: Boolean): ValidationResult {
         val validationRequest = ValidationRequest(
             direction,
             message.messageId,
@@ -36,7 +36,7 @@ class DokumentValidator(val httpClient: CpaRepoClient) {
         }
 
         if (!validationResult.valid()) throw EbmsException(validationResult.error!!)
-        if (sjekSignature) {
+        if (checkSignature) {
             runCatching {
                 message.sjekkSignature(validationResult.payloadProcessing!!.signingCertificate)
             }.onFailure {


### PR DESCRIPTION
Bakgrunn: Tidligere så sjekkes ikke om payload reponsen inneholder `error` objekt, som gjorde at selv om payload validering feilet, så hoppet den bare videre i prosessene og skapte problemer videre  i flyten.

Log eksempel på flyt der vi kaster en feil her vi kaster EbmsException ved error i Payload: https://logs.adeo.no/app/discover#/doc/96e648c0-980a-11e9-830a-e17bbd64b4db/.ds-navlogs-2025.02.08-001430?id=AZTv1Y1kz4eMkZPfmzJr

```log
no.nav.emottak.melding.feil.EbmsException: Processing has failed
	at no.nav.emottak.ebms.processing.ProcessingService.processMessage(ProcessingService.kt:74)
	at no.nav.emottak.ebms.processing.ProcessingService.access$processMessage(ProcessingService.kt:23)
	at no.nav.emottak.ebms.processing.ProcessingService$processMessage$1.invokeSuspend(ProcessingService.kt)
	at dev.reformator.stacktracedecoroutinator.stdlib.StdlibKt.decoroutinatorResumeWith$lambda$1(stdlib.kt:38)
	at no.nav.emottak.ebms.RoutesKt$postEbmsSync$1.invokeSuspend(Routes.kt:87)
	at io.ktor.server.routing.Route$buildPipeline$1$1.invokeSuspend(Route.kt:116)
	at dev.reformator.stacktracedecoroutinator.stdlib.StdlibKt.decoroutinatorResumeWith(stdlib.kt:114)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(continuation-stdlib.kt:27)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:104)
	at io.opentelemetry.javaagent.instrumentation.kotlinxcoroutines.RunnableWrapper.lambda$stopPropagation$0(RunnableWrapper.java:16)
	at io.opentelemetry.javaagent.bootstrap.executors.ContextPropagatingRunnable.run(ContextPropagatingRunnable.java:37)
	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:173)
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:166)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:470)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:569)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.ktor.server.netty.EventLoopGroupProxy$Companion.create$lambda$1$lambda$0(NettyApplicationEngine.kt:296)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Unknown Source)
Caused by: no.nav.emottak.melding.feil.EbmsException: Payload Processing has failed: Feil(code=UNKNOWN, descriptionText=Feil ved opprettelse av OCSP request, severity=Error)
	at no.nav.emottak.ebms.processing.ProcessingService.processMessage(ProcessingService.kt:43)
	... 19 common frames omitted
```

Responsen ut ser da slik ut:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<ns5:Envelope xmlns:ns5="http://schemas.xmlsoap.org/soap/envelope/"
              xmlns:ns4="http://www.oasis-open.org/committees/ebxml-msg/schema/msg-header-2_0.xsd"
>
    <ns5:Header>
        <ns4:MessageHeader ns4:version="2.0" ns5:mustUnderstand="1">
            <ns4:From>
                <ns4:PartyId ns4:type="HER">79768</ns4:PartyId>
                <ns4:Role>Fastlegeregister</ns4:Role>
            </ns4:From>
            <ns4:To>
                <ns4:PartyId ns4:type="HER">13579</ns4:PartyId>
                <ns4:Role>Fastlege</ns4:Role>
            </ns4:To>
            <ns4:CPAId>nav:qass:36666</ns4:CPAId>
            <ns4:ConversationId>873306ed-3aab-49fc-9b07-37365fba68fe</ns4:ConversationId>
            <ns4:Service ns4:type="string">urn:oasis:names:tc:ebxml-msg:service</ns4:Service>
            <ns4:Action>MessageError</ns4:Action>
            <ns4:MessageData>
                <ns4:MessageId>6dab9643-ee27-4e87-8c24-d078b412e452</ns4:MessageId>
                <ns4:Timestamp>2025-02-10T13:29:14.141+01:00</ns4:Timestamp>
                <ns4:RefToMessageId>2bebd3b9-cb68-4c18-a31b-71d9fed265a7</ns4:RefToMessageId>
            </ns4:MessageData>
        </ns4:MessageHeader>
        <ns4:SyncReply ns4:version="2.0" ns5:actor="http://schemas.xmlsoap.org/soap/actor/next" ns5:mustUnderstand="1"/>
        <ns4:ErrorList ns4:highestSeverity="Error" ns4:version="2.0" ns5:mustUnderstand="1">
            <ns4:Error ns4:errorCode="Unknown" ns4:id="ERROR_ID" ns4:severity="Error">
                <ns4:Description xml:lang="no">Processing has failed</ns4:Description>
            </ns4:Error>
        </ns4:ErrorList>
    </ns5:Header>
    <ns5:Body/>
</ns5:Envelope>
```
