### PR TITLE
Fjernet publisering av emottak-utils fra old-build workflow

### DIFF
--- a/.github/workflows/old-build.yaml
+++ b/.github/workflows/old-build.yaml
@@ -45,13 +45,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GITHUB_USERNAME: x-access-token
         GITHUB_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-    - name: Publish emottak-utils
-      run: ./gradlew emottak-utils:publish
-      continue-on-error: true
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GITHUB_USERNAME: x-access-token
-        GITHUB_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
     - name: Login to GitHub Packages Docker Registry
       uses: docker/login-action@v3
       with:


### PR DESCRIPTION
`emottak-utils` kan bli publisert gjennom `emottak-utils` workflow.