### PR TITLE
Removing decoroutinator i ebms-provider

### DIFF
--- a/ebms-provider/src/main/kotlin/no/nav/emottak/ebms/App.kt
+++ b/ebms-provider/src/main/kotlin/no/nav/emottak/ebms/App.kt
@@ -7,7 +7,6 @@ import arrow.continuations.SuspendApp
 import arrow.continuations.ktor.server
 import arrow.core.raise.result
 import arrow.fx.coroutines.resourceScope
-import dev.reformator.stacktracedecoroutinator.runtime.DecoroutinatorRuntime
 import io.ktor.server.application.Application
 import io.ktor.server.netty.Netty
 import io.ktor.server.routing.routing
@@ -18,7 +17,6 @@ import kotlinx.coroutines.awaitCancellation
 import no.nav.emottak.ebms.processing.ProcessingService
 import no.nav.emottak.ebms.sendin.SendInService
 import no.nav.emottak.ebms.validation.DokumentValidator
-import no.nav.emottak.utils.getEnvVar
 import org.slf4j.LoggerFactory
 
 val log = LoggerFactory.getLogger("no.nav.emottak.ebms.App")
@@ -26,9 +24,6 @@ val log = LoggerFactory.getLogger("no.nav.emottak.ebms.App")
 fun logger() = log
 fun main() = SuspendApp {
     System.setProperty("io.ktor.http.content.multipart.skipTempFile", "true")
-    if (getEnvVar("NAIS_CLUSTER_NAME", "local") != "prod-fss") {
-        DecoroutinatorRuntime.load()
-    }
 
     val processingClient = PayloadProcessingClient(scopedAuthHttpClient(EBMS_PAYLOAD_SCOPE))
     val processingService = ProcessingService(processingClient)


### PR DESCRIPTION
Samme feil som nevnt i https://github.com/navikt/team-emottak-docs/issues/161 skjer i `ebms-provider`

```
java.lang.IllegalStateException: No compatible attachment provider is available
	at net.bytebuddy.agent.ByteBuddyAgent.install(ByteBuddyAgent.java:627)
	at net.bytebuddy.agent.ByteBuddyAgent.install(ByteBuddyAgent.java:611)
	at net.bytebuddy.agent.ByteBuddyAgent.install(ByteBuddyAgent.java:563)
	at net.bytebuddy.agent.ByteBuddyAgent.install(ByteBuddyAgent.java:540)
	at dev.reformator.stacktracedecoroutinator.runtime.DecoroutinatorRuntime.load(runtime-jvm.kt:23)
	at no.nav.emottak.ebms.AppKt$main$1.invokeSuspend(App.kt:30)
	at no.nav.emottak.ebms.AppKt$main$1.invoke(App.kt)
	at no.nav.emottak.ebms.AppKt$main$1.invoke(App.kt)
	at arrow.continuations.SuspendAppKt$SuspendApp$2$1$job$1.invokeSuspend(SuspendApp.kt:35)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
	at io.opentelemetry.javaagent.instrumentation.kotlinxcoroutines.RunnableWrapper.lambda$stopPropagation$0(RunnableWrapper.java:16)
	at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:89)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:586)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:829)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:717)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:704)
```


Det oppsto etter endringene i https://github.com/navikt/ebxml-processor/pull/119/files, men da kun for `ebms-provider`. Ikke `cpa-repo` eller `ebms-payload`. Det er litt uklart hvilken av endringene som utløste det.

Et annet spørsmål er om vi trenger decoroutinator i det hele tatt?