### PR TITLE
#158 deler av UUID på x-message id blir sensurert

### DIFF
--- a/cpa-repo/src/main/resources/logback.xml
+++ b/cpa-repo/src/main/resources/logback.xml
@@ -5,7 +5,7 @@
             <provider class="net.logstash.logback.composite.loggingevent.ArgumentsJsonProvider" />
             <jsonGeneratorDecorator class="net.logstash.logback.mask.MaskingJsonGeneratorDecorator">
                 <valueMask>
-                    <value>\d{11}</value>
+                    <value><![CDATA[(?<!-.|.-)\d{11}]]></value>
                     <value>\d{6}\s\d{5}</value>
                     <mask>***********</mask>
                 </valueMask>

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/App.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/App.kt
@@ -164,6 +164,11 @@ fun Application.ebmsProviderModule(
 ) {
     val appMicrometerRegistry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
 
+    log.info("Logging test: 11cc63e2-97e9-4f24-9127-a12345678901")
+    log.info("Logging test: 11cc63e2-97e9-4f24-9127-123456789012")
+    log.info("Logging test: 11cc63e2-97e9-4f24-9127--12345678901")
+    log.info("Logging test: 11cc63e2-97e9-4f24-9127-ab12345678901")
+
     installMicrometerRegistry(appMicrometerRegistry)
     installContentNegotiation()
     installAuthentication()

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/App.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/App.kt
@@ -164,11 +164,6 @@ fun Application.ebmsProviderModule(
 ) {
     val appMicrometerRegistry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
 
-    log.info("Logging test: 11cc63e2-97e9-4f24-9127-a12345678901")
-    log.info("Logging test: 11cc63e2-97e9-4f24-9127-123456789012")
-    log.info("Logging test: 11cc63e2-97e9-4f24-9127--12345678901")
-    log.info("Logging test: 11cc63e2-97e9-4f24-9127-ab12345678901")
-
     installMicrometerRegistry(appMicrometerRegistry)
     installContentNegotiation()
     installAuthentication()

--- a/ebms-async/src/main/resources/logback.xml
+++ b/ebms-async/src/main/resources/logback.xml
@@ -5,7 +5,7 @@
             <provider class="net.logstash.logback.composite.loggingevent.ArgumentsJsonProvider" />
             <jsonGeneratorDecorator class="net.logstash.logback.mask.MaskingJsonGeneratorDecorator">
                 <valueMask>
-                    <value>\d{11}</value>
+                    <value>(?<!-.|.-)\d{11}</value>
                     <value>\d{6}\s\d{5}</value>
                     <mask>***********</mask>
                 </valueMask>

--- a/ebms-async/src/main/resources/logback.xml
+++ b/ebms-async/src/main/resources/logback.xml
@@ -5,7 +5,7 @@
             <provider class="net.logstash.logback.composite.loggingevent.ArgumentsJsonProvider" />
             <jsonGeneratorDecorator class="net.logstash.logback.mask.MaskingJsonGeneratorDecorator">
                 <valueMask>
-                    <value>(?<!-.|.-)\d{11}</value>
+                    <value><![CDATA[(?<!-.|.-)\d{11}]]></value>
                     <value>\d{6}\s\d{5}</value>
                     <mask>***********</mask>
                 </valueMask>

--- a/ebms-payload/src/main/resources/logback.xml
+++ b/ebms-payload/src/main/resources/logback.xml
@@ -5,7 +5,7 @@
             <provider class="net.logstash.logback.composite.loggingevent.ArgumentsJsonProvider" />
             <jsonGeneratorDecorator class="net.logstash.logback.mask.MaskingJsonGeneratorDecorator">
                 <valueMask>
-                    <value>\d{11}</value>
+                    <value><![CDATA[(?<!-.|.-)\d{11}]]></value>
                     <value>\d{6}\s\d{5}</value>
                     <mask>***********</mask>
                 </valueMask>

--- a/ebms-provider/src/main/resources/logback.xml
+++ b/ebms-provider/src/main/resources/logback.xml
@@ -5,7 +5,7 @@
             <provider class="net.logstash.logback.composite.loggingevent.ArgumentsJsonProvider" />
             <jsonGeneratorDecorator class="net.logstash.logback.mask.MaskingJsonGeneratorDecorator">
                 <valueMask>
-                    <value>\d{11}</value>
+                    <value><![CDATA[(?<!-.|.-)\d{11}]]></value>
                     <value>\d{6}\s\d{5}</value>
                     <mask>***********</mask>
                 </valueMask>


### PR DESCRIPTION
Denne regular expression svarer til 11 konsekvente tall med mindre en av de første 2 karakterene før disse tallene er `-`
For eksempel den svarer ikke til:
```
b5bd1d5e-fe49-4bd6-9511-a12345678901
b5bd1d5e-fe49-4bd6-9511-12345678901a
```