### PR TITLE
#202 Registrere meldingsdetaljer for innkommende meldinger

### DIFF
--- a/ebms-provider/build.gradle.kts
+++ b/ebms-provider/build.gradle.kts
@@ -32,6 +32,12 @@ tasks {
     }
 }
 
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().all {
+    compilerOptions {
+        freeCompilerArgs = listOf("-opt-in=kotlin.uuid.ExperimentalUuidApi")
+    }
+}
+
 dependencies {
     implementation(project(":felles"))
     implementation(project(":ebxml-processing-model"))

--- a/ebms-provider/src/main/kotlin/no/nav/emottak/ebms/EbmsDocumentExchange.kt
+++ b/ebms-provider/src/main/kotlin/no/nav/emottak/ebms/EbmsDocumentExchange.kt
@@ -35,7 +35,6 @@ import no.nav.emottak.message.xml.getDocumentBuilder
 import java.io.ByteArrayInputStream
 import java.nio.charset.StandardCharsets
 import java.util.Base64
-import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
 fun PartData.payload(clearText: Boolean = false): ByteArray {
@@ -70,7 +69,6 @@ fun Headers.actuallyUsefulToString(): String {
     return sb.toString()
 }
 
-@OptIn(ExperimentalUuidApi::class)
 @Throws(MimeValidationException::class)
 suspend fun ApplicationCall.receiveEbmsDokument(): EbMSDocument {
     log.info("Parsing message with Message-Id: ${request.header(SMTPHeaders.MESSAGE_ID)}")

--- a/ebms-provider/src/main/kotlin/no/nav/emottak/ebms/Routes.kt
+++ b/ebms-provider/src/main/kotlin/no/nav/emottak/ebms/Routes.kt
@@ -10,6 +10,7 @@ import no.nav.emottak.constants.SMTPHeaders
 import no.nav.emottak.ebms.model.signer
 import no.nav.emottak.ebms.processing.ProcessingService
 import no.nav.emottak.ebms.sendin.SendInService
+import no.nav.emottak.ebms.util.EventRegistrationService
 import no.nav.emottak.ebms.util.marker
 import no.nav.emottak.ebms.validation.DokumentValidator
 import no.nav.emottak.ebms.validation.MimeValidationException
@@ -24,20 +25,15 @@ import no.nav.emottak.message.model.PayloadProcessing
 import no.nav.emottak.message.model.SignatureDetails
 import no.nav.emottak.util.marker
 import no.nav.emottak.util.retrieveLoggableHeaderPairs
-import no.nav.emottak.utils.common.parseOrGenerateUuid
-import no.nav.emottak.utils.kafka.model.Event
 import no.nav.emottak.utils.kafka.model.EventType
-import no.nav.emottak.utils.kafka.service.EventLoggingService
 import no.nav.emottak.utils.serialization.toEventDataJson
-import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
-@OptIn(ExperimentalUuidApi::class)
 fun Route.postEbmsSync(
     validator: DokumentValidator,
     processingService: ProcessingService,
     sendInService: SendInService,
-    eventLoggingService: EventLoggingService
+    eventRegistrationService: EventRegistrationService
 ): Route = post("/ebms/sync") {
     log.info("Receiving synchronous request")
 
@@ -47,7 +43,7 @@ fun Route.postEbmsSync(
         call.request.validateMime()
         ebMSDocument = call.receiveEbmsDokument()
         log.info(ebMSDocument.messageHeader().marker(loggableHeaders), "Melding mottatt")
-        eventLoggingService.registerEvent(
+        eventRegistrationService.registerEvent(
             EventType.MESSAGE_RECEIVED_VIA_HTTP,
             ebMSDocument
         )
@@ -119,7 +115,7 @@ fun Route.postEbmsSync(
                     }
                 )
                 log.info(it.first.marker(), "Melding ferdig behandlet og svar returnert")
-                eventLoggingService.registerEvent(
+                eventRegistrationService.registerEvent(
                     EventType.MESSAGE_SENT_VIA_HTTP,
                     it.first.toEbmsDokument()
                 )
@@ -133,7 +129,7 @@ fun Route.postEbmsSync(
             }
             log.info(ebmsMessage.marker(), "Created MessageError response")
 
-            eventLoggingService.registerEvent(
+            eventRegistrationService.registerEvent(
                 EventType.ERROR_WHILE_SENDING_MESSAGE_VIA_HTTP,
                 ebMSDocument,
                 ebmsException.toEventDataJson()
@@ -145,7 +141,7 @@ fun Route.postEbmsSync(
     } catch (ex: Exception) {
         log.error(ebmsMessage.marker(), "Unknown error during message processing: ${ex.message}", ex)
 
-        eventLoggingService.registerEvent(
+        eventRegistrationService.registerEvent(
             EventType.ERROR_WHILE_SENDING_MESSAGE_VIA_HTTP,
             ebMSDocument,
             ex.toEventDataJson()
@@ -155,34 +151,5 @@ fun Route.postEbmsSync(
             HttpStatusCode.InternalServerError,
             ex.parseAsSoapFault()
         )
-    }
-}
-
-@OptIn(ExperimentalUuidApi::class)
-suspend fun EventLoggingService.registerEvent(
-    eventType: EventType,
-    ebMSDocument: EbMSDocument,
-    eventData: String = ""
-) {
-    log.debug("Event reg. test: Registering event for requestId: ${ebMSDocument.requestId}")
-
-    try {
-        val requestId = ebMSDocument.requestId.parseOrGenerateUuid()
-
-        log.debug("Event reg. test: RequestId: $requestId")
-
-        val event = Event(
-            eventType = eventType,
-            requestId = requestId,
-            contentId = "",
-            messageId = ebMSDocument.transform().messageId,
-            eventData = eventData
-        )
-
-        log.debug("Event reg. test: Publishing event: $event")
-        this.logEvent(event)
-        log.debug("Event reg. test: Event published successfully")
-    } catch (e: Exception) {
-        log.error("Event reg. test: Error while registering event: ${e.message}", e)
     }
 }

--- a/ebms-provider/src/main/kotlin/no/nav/emottak/ebms/Routes.kt
+++ b/ebms-provider/src/main/kotlin/no/nav/emottak/ebms/Routes.kt
@@ -43,6 +43,8 @@ fun Route.postEbmsSync(
         call.request.validateMime()
         ebMSDocument = call.receiveEbmsDokument()
         log.info(ebMSDocument.messageHeader().marker(loggableHeaders), "Melding mottatt")
+
+        eventRegistrationService.registerEventMessageDetails(ebMSDocument)
         eventRegistrationService.registerEvent(
             EventType.MESSAGE_RECEIVED_VIA_HTTP,
             ebMSDocument

--- a/ebms-provider/src/main/kotlin/no/nav/emottak/ebms/configuration/Config.kt
+++ b/ebms-provider/src/main/kotlin/no/nav/emottak/ebms/configuration/Config.kt
@@ -1,9 +1,11 @@
 package no.nav.emottak.ebms.configuration
 
+import no.nav.emottak.utils.config.EventLogging
 import no.nav.emottak.utils.config.Kafka
 
 data class Config(
     val kafka: Kafka,
+    val eventLogging: EventLogging,
     val kafkaSignalReceiver: KafkaSignalReceiver,
     val kafkaSignalProducer: KafkaSignalProducer,
     val kafkaPayloadReceiver: KafkaPayloadReceiver,

--- a/ebms-provider/src/main/kotlin/no/nav/emottak/ebms/util/EventRegistration.kt
+++ b/ebms-provider/src/main/kotlin/no/nav/emottak/ebms/util/EventRegistration.kt
@@ -1,0 +1,58 @@
+package no.nav.emottak.ebms.util
+
+import no.nav.emottak.ebms.log
+import no.nav.emottak.message.model.EbMSDocument
+import no.nav.emottak.utils.common.parseOrGenerateUuid
+import no.nav.emottak.utils.kafka.model.Event
+import no.nav.emottak.utils.kafka.model.EventType
+import no.nav.emottak.utils.kafka.service.EventLoggingService
+
+interface EventRegistrationService {
+    suspend fun registerEvent(
+        eventType: EventType,
+        ebMSDocument: EbMSDocument,
+        eventData: String = ""
+    )
+}
+
+class EventRegistrationServiceImpl(
+    private val eventLoggingService: EventLoggingService
+) : EventRegistrationService {
+    override suspend fun registerEvent(
+        eventType: EventType,
+        ebMSDocument: EbMSDocument,
+        eventData: String
+    ) {
+        log.debug("Event reg. test: Registering event for requestId: ${ebMSDocument.requestId}")
+
+        try {
+            val requestId = ebMSDocument.requestId.parseOrGenerateUuid()
+
+            log.debug("Event reg. test: RequestId: $requestId")
+
+            val event = Event(
+                eventType = eventType,
+                requestId = requestId,
+                contentId = "",
+                messageId = ebMSDocument.transform().messageId,
+                eventData = eventData
+            )
+
+            log.debug("Event reg. test: Publishing event: $event")
+            eventLoggingService.logEvent(event)
+            log.debug("Event reg. test: Event published successfully")
+        } catch (e: Exception) {
+            log.error("Event reg. test: Error while registering event: ${e.message}", e)
+        }
+    }
+}
+
+class EventRegistrationServiceFake : EventRegistrationService {
+    override suspend fun registerEvent(
+        eventType: EventType,
+        ebMSDocument: EbMSDocument,
+        eventData: String
+    ) {
+        log.debug("Event reg. test: Registering event $eventType for ebMSDocument: $ebMSDocument and eventData: $eventData")
+    }
+}

--- a/ebms-provider/src/test/kotlin/no/nav/emottak/ebms/EbmsRoutFellesIT.kt
+++ b/ebms-provider/src/test/kotlin/no/nav/emottak/ebms/EbmsRoutFellesIT.kt
@@ -14,6 +14,7 @@ import io.mockk.coVerify
 import io.mockk.mockk
 import no.nav.emottak.ebms.processing.ProcessingService
 import no.nav.emottak.ebms.sendin.SendInService
+import no.nav.emottak.ebms.util.EventRegistrationServiceFake
 import no.nav.emottak.ebms.validation.DokumentValidator
 import no.nav.emottak.ebms.validation.MimeHeaders
 import no.nav.emottak.message.ebxml.errorList
@@ -27,7 +28,6 @@ import no.nav.emottak.message.model.ValidationResult
 import no.nav.emottak.message.xml.xmlMarshaller
 import no.nav.emottak.util.decodeBase64
 import no.nav.emottak.utils.environment.getEnvVar
-import no.nav.emottak.utils.kafka.service.EventLoggingService
 import org.apache.xml.security.algorithms.MessageDigestAlgorithm
 import org.apache.xml.security.signature.XMLSignature
 import org.junit.jupiter.api.Assertions
@@ -39,7 +39,7 @@ abstract class EbmsRoutFellesIT(val endpoint: String) {
 
     val validMultipartRequest = validMultipartRequest()
     val processingService = mockk<ProcessingService>()
-    val eventLoggingService = mockk<EventLoggingService>()
+    val eventRegistrationService = EventRegistrationServiceFake()
     val mockProcessConfig = ProcessConfig(
         true,
         true,
@@ -69,7 +69,7 @@ abstract class EbmsRoutFellesIT(val endpoint: String) {
             }
 
             routing {
-                postEbmsSync(dokumentValidator, processingService, SendInService(sendInClient), eventLoggingService)
+                postEbmsSync(dokumentValidator, processingService, SendInService(sendInClient), eventRegistrationService)
             }
         }
         externalServices {

--- a/ebms-provider/src/test/kotlin/no/nav/emottak/ebms/EbmsRouteSyncIT.kt
+++ b/ebms-provider/src/test/kotlin/no/nav/emottak/ebms/EbmsRouteSyncIT.kt
@@ -39,12 +39,10 @@ import no.nav.emottak.utils.environment.getEnvVar
 import org.apache.xml.security.algorithms.MessageDigestAlgorithm
 import org.apache.xml.security.signature.XMLSignature
 import org.junit.jupiter.api.Test
-import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
 private const val SYNC_PATH = "/ebms/sync"
 
-@OptIn(ExperimentalUuidApi::class)
 class EbmsRouteSyncIT : EbmsRoutFellesIT(SYNC_PATH) {
 
     fun <T> testSyncApp(testBlock: suspend ApplicationTestBuilder.() -> T) = testApplication {
@@ -69,7 +67,7 @@ class EbmsRouteSyncIT : EbmsRoutFellesIT(SYNC_PATH) {
                 incomingMessage
             }
             routing {
-                postEbmsSync(dokumentValidator, processingService, SendInService(sendInClient), eventLoggingService)
+                postEbmsSync(dokumentValidator, processingService, SendInService(sendInClient), eventRegistrationService)
             }
         }
         externalServices {
@@ -131,7 +129,6 @@ class EbmsRouteSyncIT : EbmsRoutFellesIT(SYNC_PATH) {
         testBlock()
     }
 
-    @OptIn(ExperimentalUuidApi::class)
     @Test
     fun `Valid payload request should trigger processing and validation on way out`() = testSyncApp {
         mockkStatic(EbMSDocument::signer)
@@ -149,7 +146,6 @@ class EbmsRouteSyncIT : EbmsRoutFellesIT(SYNC_PATH) {
         println("----=_Part_" + Uuid.random().toString())
     }
 
-    @OptIn(ExperimentalUuidApi::class)
     @Test
     fun `Feilmelding fra fagsystemet må propageres til brukeren`() = testSyncApp {
         val soapFault = "<SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\"><SOAP-ENV:Header/><SOAP-ENV:Body><SOAP-ENV:Fault><faultcode>SOAP-ENV:Server</faultcode><faultstring>Noe gikk galt i fagsystemet</faultstring></SOAP-ENV:Fault></SOAP-ENV:Body></SOAP-ENV:Envelope>"

--- a/ebms-provider/src/test/kotlin/no/nav/emottak/ebms/validation/MimeValidationIT.kt
+++ b/ebms-provider/src/test/kotlin/no/nav/emottak/ebms/validation/MimeValidationIT.kt
@@ -15,6 +15,7 @@ import no.nav.emottak.ebms.payload
 import no.nav.emottak.ebms.postEbmsSync
 import no.nav.emottak.ebms.processing.ProcessingService
 import no.nav.emottak.ebms.sendin.SendInService
+import no.nav.emottak.ebms.util.EventRegistrationServiceFake
 import no.nav.emottak.ebms.validMultipartRequest
 import no.nav.emottak.message.ebxml.errorList
 import no.nav.emottak.message.ebxml.messageHeader
@@ -22,7 +23,6 @@ import no.nav.emottak.message.model.ErrorCode
 import no.nav.emottak.message.model.Feil
 import no.nav.emottak.message.model.ValidationResult
 import no.nav.emottak.message.xml.xmlMarshaller
-import no.nav.emottak.utils.kafka.service.EventLoggingService
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -36,7 +36,7 @@ class MimeValidationIT {
 
     val validMultipartRequest = validMultipartRequest()
     val cpaRepoClient = mockk<CpaRepoClient>()
-    val eventLoggingService = mockk<EventLoggingService>()
+    val eventRegistrationService = EventRegistrationServiceFake()
 
     fun <T> mimeTestApp(testBlock: suspend ApplicationTestBuilder.() -> T) = testApplication {
         application {
@@ -44,7 +44,7 @@ class MimeValidationIT {
             val processingService = mockk<ProcessingService>()
             val sendInService = mockk<SendInService>()
             routing {
-                postEbmsSync(dokumentValidator, processingService, sendInService, eventLoggingService)
+                postEbmsSync(dokumentValidator, processingService, sendInService, eventRegistrationService)
             }
         }
         externalServices {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,7 +21,7 @@ dependencyResolutionManagement {
             version("hoplite", "2.8.2")
             version("logback", "1.5.17")
             version("logstash", "8.0")
-            version("emottak-utils", "0.2.2")
+            version("emottak-utils", "0.2.4")
 
             library("bcpkix-jdk18on", "org.bouncycastle", "bcpkix-jdk18on").versionRef("bouncycastle")
             library("bcprov-jdk18on", "org.bouncycastle", "bcprov-jdk18on").versionRef("bouncycastle")


### PR DESCRIPTION
1. Opprettet `EventRegistrationService`.
2. Lagt til registrering av meldingsdetaljer for innkommende meldinger.
3. Liten refaktorisering: fjernet `@OptIn(ExperimentalUuidApi::class)` merknad fra klasser.