### PR TITLE
#188 Registrere hendelser i ebms-payload

### DIFF
--- a/.nais/ebms-payload-dev.yaml
+++ b/.nais/ebms-payload-dev.yaml
@@ -57,6 +57,8 @@ spec:
     paths:
       - kvPath: serviceuser/data/dev/srv-ebms-payload
         mountPath: /var/run/secrets/nais.io/vault/serviceuser
+  kafka:
+    pool: nav-dev
   webproxy: true
   envFrom:
     - secret: ebms-payload-secret

--- a/ebms-payload/src/main/kotlin/no/nav/emottak/payload/App.kt
+++ b/ebms-payload/src/main/kotlin/no/nav/emottak/payload/App.kt
@@ -15,7 +15,11 @@ import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.server.routing.routing
 import io.micrometer.prometheusmetrics.PrometheusConfig
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
+import no.nav.emottak.payload.configuration.config
+import no.nav.emottak.payload.util.EventRegistrationServiceImpl
 import no.nav.emottak.utils.environment.getEnvVar
+import no.nav.emottak.utils.kafka.client.EventPublisherClient
+import no.nav.emottak.utils.kafka.service.EventLoggingService
 import no.nav.security.token.support.v3.tokenValidationSupport
 import org.slf4j.LoggerFactory
 import java.net.InetSocketAddress
@@ -27,10 +31,17 @@ fun main() {
     if (getEnvVar("NAIS_CLUSTER_NAME", "local") != "prod-fss") {
         DecoroutinatorRuntime.load()
     }
+
+    val kafkaPublisherClient = EventPublisherClient(config().kafka)
+    val eventLoggingService = EventLoggingService(config().eventLogging, kafkaPublisherClient)
+    val eventRegistrationService = EventRegistrationServiceImpl(eventLoggingService)
+
+    val processor = Processor(eventRegistrationService)
+
     embeddedServer(
         factory = Netty,
         port = 8080,
-        module = payloadApplicationModule()
+        module = payloadApplicationModule(processor)
     ).start(wait = true)
 }
 private val httpProxyUrl = getEnvVar("HTTP_PROXY", "")
@@ -47,7 +58,7 @@ fun defaultHttpClient(): () -> HttpClient {
     }
 }
 
-fun payloadApplicationModule(): Application.() -> Unit {
+fun payloadApplicationModule(processor: Processor): Application.() -> Unit {
     return {
         install(ContentNegotiation) {
             json()
@@ -64,7 +75,7 @@ fun payloadApplicationModule(): Application.() -> Unit {
             registerHealthEndpoints(appMicrometerRegistry)
 
             authenticate(AZURE_AD_AUTH) {
-                postPayload()
+                postPayload(processor)
             }
         }
     }

--- a/ebms-payload/src/main/kotlin/no/nav/emottak/payload/Processor.kt
+++ b/ebms-payload/src/main/kotlin/no/nav/emottak/payload/Processor.kt
@@ -22,7 +22,6 @@ import no.nav.emottak.util.retrieveSignatureElement
 import no.nav.emottak.util.signatur.SignaturVerifisering
 import no.nav.emottak.utils.kafka.model.EventDataType
 import no.nav.emottak.utils.kafka.model.EventType
-import no.nav.emottak.utils.serialization.toEventDataJson
 import org.slf4j.Marker
 import java.io.ByteArrayInputStream
 

--- a/ebms-payload/src/main/kotlin/no/nav/emottak/payload/Processor.kt
+++ b/ebms-payload/src/main/kotlin/no/nav/emottak/payload/Processor.kt
@@ -9,6 +9,7 @@ import no.nav.emottak.payload.crypto.PayloadSignering
 import no.nav.emottak.payload.crypto.payloadSigneringConfig
 import no.nav.emottak.payload.juridisklogg.JuridiskLoggService
 import no.nav.emottak.payload.ocspstatus.OcspStatusService
+import no.nav.emottak.payload.util.EventRegistrationService
 import no.nav.emottak.payload.util.GZipUtil
 import no.nav.emottak.util.createDocument
 import no.nav.emottak.util.createX509Certificate
@@ -19,16 +20,15 @@ import no.nav.emottak.util.signatur.SignaturVerifisering
 import org.slf4j.Marker
 import java.io.ByteArrayInputStream
 
-val processor = Processor()
 class Processor(
-    private val kryptering: Kryptering = Kryptering(),
-    private val dekryptering: Dekryptering = Dekryptering(),
-    private val signering: PayloadSignering = PayloadSignering(),
-    private val gZipUtil: GZipUtil = GZipUtil(),
-    private val signatureVerifisering: SignaturVerifisering = SignaturVerifisering(),
-    private val juridiskLogging: JuridiskLoggService = JuridiskLoggService()
+    private val eventRegistrationService: EventRegistrationService
 ) {
-
+    private val kryptering: Kryptering = Kryptering()
+    private val dekryptering: Dekryptering = Dekryptering()
+    private val signering: PayloadSignering = PayloadSignering()
+    private val gZipUtil: GZipUtil = GZipUtil()
+    private val signatureVerifisering: SignaturVerifisering = SignaturVerifisering()
+    private val juridiskLogging: JuridiskLoggService = JuridiskLoggService()
     private val ocspStatusService = OcspStatusService(
         defaultHttpClient().invoke(),
         KeyStoreManager(

--- a/ebms-payload/src/main/kotlin/no/nav/emottak/payload/Processor.kt
+++ b/ebms-payload/src/main/kotlin/no/nav/emottak/payload/Processor.kt
@@ -56,11 +56,6 @@ class Processor(
             }
         } catch (e: Exception) {
             log.error(payloadRequest.marker(), "Exception occurred while saving message to juridisk logg", e)
-            eventRegistrationService.registerEvent(
-                EventType.ERROR_WHILE_SAVING_MESSAGE_IN_JURIDISK_LOGG,
-                payloadRequest,
-                e.toEventDataJson()
-            )
             throw e
         }
     }

--- a/ebms-payload/src/main/kotlin/no/nav/emottak/payload/Routes.kt
+++ b/ebms-payload/src/main/kotlin/no/nav/emottak/payload/Routes.kt
@@ -71,7 +71,7 @@ fun Route.postPayload(
     }
 }
 
-private fun createOutgoingPayloadResponse(request: PayloadRequest, processor: Processor) = PayloadResponse(
+private suspend fun createOutgoingPayloadResponse(request: PayloadRequest, processor: Processor) = PayloadResponse(
     processedPayload = processor.processOutgoing(request)
 )
 
@@ -81,7 +81,7 @@ private suspend fun createIncomingPayloadResponse(
     processor: Processor
 ): PayloadResponse {
     val readablePayload =
-        processor.convertToReadablePayload(request.payload, processConfig.kryptering, processConfig.komprimering).also {
+        processor.convertToReadablePayload(request, processConfig.kryptering, processConfig.komprimering).also {
             if (processConfig.kryptering) log.info(request.marker(), "Payload dekryptert")
             if (processConfig.komprimering) log.info(request.marker(), "Payload dekomprimert")
         }

--- a/ebms-payload/src/main/kotlin/no/nav/emottak/payload/Routes.kt
+++ b/ebms-payload/src/main/kotlin/no/nav/emottak/payload/Routes.kt
@@ -90,8 +90,8 @@ private suspend fun createIncomingPayloadResponse(
             processedPayload = processor.validateReadablePayload(
                 request.marker(),
                 readablePayload,
-                processConfig.signering,
-                processConfig.ocspSjekk
+                request,
+                processConfig
             ).also {
                 if (processConfig.signering) log.info(request.marker(), "Payload signatur verifisert")
                 if (processConfig.ocspSjekk) log.info(request.marker(), "Payload signatur ocsp sjekket")

--- a/ebms-payload/src/main/kotlin/no/nav/emottak/payload/Routes.kt
+++ b/ebms-payload/src/main/kotlin/no/nav/emottak/payload/Routes.kt
@@ -20,11 +20,15 @@ import no.nav.emottak.message.model.Payload
 import no.nav.emottak.message.model.PayloadRequest
 import no.nav.emottak.message.model.PayloadResponse
 import no.nav.emottak.message.model.ProcessConfig
+import no.nav.emottak.payload.util.EventRegistrationService
 import no.nav.emottak.payload.util.marshal
 import no.nav.emottak.payload.util.unmarshal
 import no.nav.emottak.util.marker
 
-fun Route.postPayload(processor: Processor) = post("/payload") {
+fun Route.postPayload(
+    processor: Processor,
+    eventRegistrationService: EventRegistrationService
+) = post("/payload") {
     val request: PayloadRequest = call.receive(PayloadRequest::class)
 
     // TODO: Skal brukes i kall mot Event-logging:

--- a/ebms-payload/src/main/kotlin/no/nav/emottak/payload/configuration/Config.kt
+++ b/ebms-payload/src/main/kotlin/no/nav/emottak/payload/configuration/Config.kt
@@ -1,10 +1,15 @@
 package no.nav.emottak.payload.configuration
 
+import no.nav.emottak.utils.config.EventLogging
+import no.nav.emottak.utils.config.Kafka
+
 data class CertificateAuthority(
     val dn: String,
     val ocspUrl: String
 )
 
 data class Config(
-    val caList: List<CertificateAuthority>
+    val caList: List<CertificateAuthority>,
+    val kafka: Kafka,
+    val eventLogging: EventLogging
 )

--- a/ebms-payload/src/main/kotlin/no/nav/emottak/payload/configuration/Configurator.kt
+++ b/ebms-payload/src/main/kotlin/no/nav/emottak/payload/configuration/Configurator.kt
@@ -1,16 +1,16 @@
-package no.nav.emottak.payload
+package no.nav.emottak.payload.configuration
 
 import com.sksamuel.hoplite.ConfigLoader
 import com.sksamuel.hoplite.ExperimentalHoplite
 import com.sksamuel.hoplite.addEnvironmentSource
 import com.sksamuel.hoplite.addResourceSource
-import no.nav.emottak.payload.configuration.Config
 import no.nav.emottak.utils.environment.getEnvVar
 
 @OptIn(ExperimentalHoplite::class)
 fun config() = ConfigLoader.builder()
     .addEnvironmentSource()
     .addResourceSource(certificateAuthorityResourceResolver())
+    .addResourceSource("/kafka_common.conf")
     .withExplicitSealedTypes()
     .build()
     .loadConfigOrThrow<Config>()

--- a/ebms-payload/src/main/kotlin/no/nav/emottak/payload/crypto/Kryptering.kt
+++ b/ebms-payload/src/main/kotlin/no/nav/emottak/payload/crypto/Kryptering.kt
@@ -45,7 +45,7 @@ fun krypterDokument(doc: ByteArray, certificate: X509Certificate): ByteArray {
     return try {
         krypterDokument(doc, listOf(certificate))
     } catch (e: Exception) {
-        throw EncryptionException("Feil ved kryptering av dokument", e)
+        throw EncryptionException("Feil ved kryptering av dokument. Sertifikat: ${getEncryptionDetails(certificate)}", e)
     }
 }
 
@@ -68,4 +68,13 @@ private fun krypterDokument(input: ByteArray, certificates: List<X509Certificate
     } catch (e: CMSException) {
         throw EncryptionException("Feil ved kryptering av dokument", e)
     }
+}
+
+fun getEncryptionDetails(certificate: X509Certificate): String {
+    return """
+            X.509 Certificate: 
+            Subject: ${certificate.subjectX500Principal}
+            Issuer: ${certificate.issuerX500Principal}
+            Serial Number: ${certificate.serialNumber}
+    """.trimIndent()
 }

--- a/ebms-payload/src/main/kotlin/no/nav/emottak/payload/juridisklogg/JuridiskLoggException.kt
+++ b/ebms-payload/src/main/kotlin/no/nav/emottak/payload/juridisklogg/JuridiskLoggException.kt
@@ -1,0 +1,3 @@
+package no.nav.emottak.payload.juridisklogg
+
+class JuridiskLoggException(message: String, exception: Exception? = null) : Exception(message, exception)

--- a/ebms-payload/src/main/kotlin/no/nav/emottak/payload/juridisklogg/JuridiskLoggService.kt
+++ b/ebms-payload/src/main/kotlin/no/nav/emottak/payload/juridisklogg/JuridiskLoggService.kt
@@ -65,7 +65,7 @@ class JuridiskLoggService() {
                 }
             } catch (e: Exception) {
                 log.error(payloadRequest.marker(), "Exception occurred during sending message to juridisk logg: ${e.message}", e)
-                throw e
+                throw JuridiskLoggException("Exception occurred during sending message to juridisk logg", e)
             } finally {
                 httpClient.close()
             }

--- a/ebms-payload/src/main/kotlin/no/nav/emottak/payload/ocspstatus/OcspStatusService.kt
+++ b/ebms-payload/src/main/kotlin/no/nav/emottak/payload/ocspstatus/OcspStatusService.kt
@@ -7,7 +7,7 @@ import io.ktor.client.statement.readRawBytes
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import no.nav.emottak.crypto.KeyStoreManager
-import no.nav.emottak.payload.config
+import no.nav.emottak.payload.configuration.config
 import no.nav.emottak.payload.log
 import no.nav.emottak.utils.environment.getEnvVar
 import org.bouncycastle.asn1.ocsp.OCSPObjectIdentifiers

--- a/ebms-payload/src/main/kotlin/no/nav/emottak/payload/util/CompressionException.kt
+++ b/ebms-payload/src/main/kotlin/no/nav/emottak/payload/util/CompressionException.kt
@@ -1,0 +1,3 @@
+package no.nav.emottak.payload.util
+
+class CompressionException(message: String, exception: Exception? = null) : Exception(message, exception)

--- a/ebms-payload/src/main/kotlin/no/nav/emottak/payload/util/DecompressionException.kt
+++ b/ebms-payload/src/main/kotlin/no/nav/emottak/payload/util/DecompressionException.kt
@@ -1,0 +1,3 @@
+package no.nav.emottak.payload.util
+
+class DecompressionException(message: String, exception: Exception? = null) : Exception(message, exception)

--- a/ebms-payload/src/main/kotlin/no/nav/emottak/payload/util/EventRegistration.kt
+++ b/ebms-payload/src/main/kotlin/no/nav/emottak/payload/util/EventRegistration.kt
@@ -1,0 +1,56 @@
+package no.nav.emottak.payload.util
+
+import no.nav.emottak.message.model.PayloadRequest
+import no.nav.emottak.payload.log
+import no.nav.emottak.utils.common.parseOrGenerateUuid
+import no.nav.emottak.utils.kafka.model.Event
+import no.nav.emottak.utils.kafka.model.EventType
+import no.nav.emottak.utils.kafka.service.EventLoggingService
+import kotlin.uuid.ExperimentalUuidApi
+
+interface EventRegistrationService {
+    suspend fun registerEvent(
+        eventType: EventType,
+        payloadRequest: PayloadRequest,
+        eventData: String = "{}"
+    )
+}
+
+class EventRegistrationServiceImpl(
+    private val eventLoggingService: EventLoggingService
+) : EventRegistrationService {
+    @OptIn(ExperimentalUuidApi::class)
+    override suspend fun registerEvent(
+        eventType: EventType,
+        payloadRequest: PayloadRequest,
+        eventData: String
+    ) {
+        log.debug("Registering event for requestId: ${payloadRequest.requestId}")
+
+        try {
+            val event = Event(
+                eventType = eventType,
+                requestId = payloadRequest.requestId.parseOrGenerateUuid(),
+                contentId = "",
+                messageId = payloadRequest.messageId,
+                eventData = eventData
+            )
+            log.debug("Registering event: {}", event)
+
+            eventLoggingService.logEvent(event)
+            log.debug("Event is registered successfully")
+        } catch (e: Exception) {
+            log.error("Error while registering event: ${e.message}", e)
+        }
+    }
+}
+
+class EventRegistrationServiceFake : EventRegistrationService {
+    override suspend fun registerEvent(
+        eventType: EventType,
+        payloadRequest: PayloadRequest,
+        eventData: String
+    ) {
+        log.debug("Registering event $eventType for validationRequest: $payloadRequest and eventData: $eventData")
+    }
+}

--- a/ebms-payload/src/main/kotlin/no/nav/emottak/payload/util/GZipUtil.kt
+++ b/ebms-payload/src/main/kotlin/no/nav/emottak/payload/util/GZipUtil.kt
@@ -21,7 +21,7 @@ class GZipUtil {
             gzip.write(byteArray)
             gzip.close()
         } catch (e: Exception) {
-            throw e
+            throw CompressionException("Exception occurred while compressing payload", e)
         }
         return out.toByteArray()
     }
@@ -40,7 +40,7 @@ class GZipUtil {
                 out.write(buffer, 0, n)
             }
         } catch (e: Exception) {
-            throw e
+            throw DecompressionException("Exception occurred while decompressing payload", e)
         }
         return out.toByteArray()
     }

--- a/ebms-payload/src/main/resources/ca_dev.conf
+++ b/ebms-payload/src/main/resources/ca_dev.conf
@@ -13,4 +13,7 @@ caList = [
     {dn = "CN=Commfides Natural Person - G3 - TEST, OID.2.5.4.97=NTRNO-988312495, O=Commfides Norge AS, C=NO", ocspUrl = "https://ocsp1.test.commfides.com/ocsp"}
 ]
 
+kafka {
+  groupId = "ebms-payload"
+}
 

--- a/ebms-payload/src/main/resources/ca_prod.conf
+++ b/ebms-payload/src/main/resources/ca_prod.conf
@@ -11,4 +11,6 @@ caList = [
     {dn = "C=NO, O=Commfides Norge AS - 988 312 495, OU=Commfides Trust Environment (c) 2011 Commfides Norge AS, CN=CPN Person High SHA256 CLASS 3", ocspUrl = "https://ocsp1.commfides.com/ocsp", issuer = "COMMFIDES"}
 ]
 
-
+kafka {
+  groupId = "ebms-payload"
+}

--- a/ebms-payload/src/test/kotlin/no/nav/emottak/payload/PayloadIntegrationTest.kt
+++ b/ebms-payload/src/test/kotlin/no/nav/emottak/payload/PayloadIntegrationTest.kt
@@ -74,10 +74,11 @@ class PayloadIntegrationTest {
     private fun <T> ebmsPayloadTestApp(testBlock: suspend ApplicationTestBuilder.() -> T) = testApplication {
         setupEnv()
         configureOcspStatusService()
+
         val eventRegistrationService = EventRegistrationServiceFake()
         val processor = Processor(eventRegistrationService)
 
-        application(payloadApplicationModule(processor))
+        application(payloadApplicationModule(processor, eventRegistrationService))
         testBlock()
     }
 


### PR DESCRIPTION
1. Lagt til registrering av hendelser:
```
    MESSAGE_SAVED_IN_JURIDISK_LOGG
    ERROR_WHILE_SAVING_MESSAGE_IN_JURIDISK_LOGG
    MESSAGE_ENCRYPTED
    MESSAGE_ENCRYPTION_FAILED
    MESSAGE_DECRYPTED
    MESSAGE_DECRYPTION_FAILED
    MESSAGE_COMPRESSED
    MESSAGE_COMPRESSION_FAILED
    MESSAGE_DECOMPRESSED
    MESSAGE_DECOMPRESSION_FAILED
    SIGNATURE_CHECK_SUCCESSFUL
    SIGNATURE_CHECK_FAILED
    OCSP_CHECK_SUCCESSFUL
    OCSP_CHECK_FAILED
```
2. Refaktorisert `Processor` so at den ble en vanlig avhengighet ikke et globalt objekt.
3. Fikset `Payload endepunkt med OCSP` test, så at den fungerer sammen med refaktorisert `Processor`

