### PR TITLE
#191 Registrere hendelser i ebms-async

### DIFF
--- a/ebms-async/build.gradle.kts
+++ b/ebms-async/build.gradle.kts
@@ -28,6 +28,12 @@ tasks {
     }
 }
 
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().all {
+    compilerOptions {
+        freeCompilerArgs = listOf("-opt-in=kotlin.uuid.ExperimentalUuidApi,com.sksamuel.hoplite.ExperimentalHoplite")
+    }
+}
+
 dependencies {
     implementation(project(":felles"))
     implementation(project(":ebms-provider"))

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/App.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/App.kt
@@ -73,8 +73,8 @@ fun main() = SuspendApp {
     val ebmsMessageDetailsRepository = EbmsMessageDetailsRepository(database)
     val processingClient = PayloadProcessingClient(scopedAuthHttpClient(EBMS_PAYLOAD_SCOPE))
     val processingService = ProcessingService(processingClient)
-    val ebmsSignalProducer = EbmsMessageProducer(config.kafkaSignalProducer.topic, config.kafkaLocal)
-    val ebmsPayloadProducer = EbmsMessageProducer(config.kafkaPayloadProducer.topic, config.kafkaLocal)
+    val ebmsSignalProducer = EbmsMessageProducer(config.kafkaSignalProducer.topic, config.kafka)
+    val ebmsPayloadProducer = EbmsMessageProducer(config.kafkaPayloadProducer.topic, config.kafka)
 
     val cpaClient = CpaRepoClient(defaultHttpClient())
     val cpaValidationService = CPAValidationService(cpaClient)
@@ -172,7 +172,7 @@ private fun CoroutineScope.launchPayloadReceiver(
         launch(Dispatchers.IO) {
             startPayloadReceiver(
                 config.kafkaPayloadReceiver.topic,
-                config.kafkaLocal,
+                config.kafka,
                 payloadMessageProcessorProvider.invoke()
             )
         }
@@ -190,7 +190,7 @@ private fun CoroutineScope.launchSignalReceiver(
                 ebmsMessageDetailsRepository,
                 cpaValidationService
             )
-            startSignalReceiver(config.kafkaSignalReceiver.topic, config.kafkaLocal, signalProcessor)
+            startSignalReceiver(config.kafkaSignalReceiver.topic, config.kafka, signalProcessor)
         }
     }
 }
@@ -249,7 +249,7 @@ fun Route.simulateError(): Route = get("/api/forceretry/{$KAFKA_OFFSET}") {
             val record = getRecord(
                 config()
                     .kafkaPayloadReceiver.topic,
-                config().kafkaLocal
+                config().kafka
                     .copy(groupId = "ebms-provider-retry"),
                 (call.parameters[KAFKA_OFFSET])?.toLong() ?: 0
             )

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/App.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/App.kt
@@ -61,7 +61,6 @@ import no.nav.emottak.utils.environment.isProdEnv
 import no.nav.emottak.utils.kafka.client.EventPublisherClient
 import no.nav.emottak.utils.kafka.service.EventLoggingService
 import org.slf4j.LoggerFactory
-import kotlin.uuid.ExperimentalUuidApi
 
 val log = LoggerFactory.getLogger("no.nav.emottak.ebms.async.App")
 
@@ -224,7 +223,6 @@ fun Application.ebmsProviderModule(
 
 const val RETRY_LIMIT = "retryLimit"
 
-@OptIn(ExperimentalUuidApi::class)
 fun Routing.retryErrors(
     payloadMessageProcessorProvider: () -> PayloadMessageProcessor
 ): Route =

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/App.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/App.kt
@@ -127,7 +127,8 @@ fun main() = SuspendApp {
                 module = {
                     ebmsProviderModule(
                         payloadRepository = payloadRepository,
-                        payloadProcessorProvider = payloadMessageProcessorProvider
+                        payloadProcessorProvider = payloadMessageProcessorProvider,
+                        eventRegistrationService = eventRegistrationService
                     )
                 }
             ).also { it.engineConfig.maxChunkSize = 100000 }
@@ -197,7 +198,8 @@ private fun CoroutineScope.launchSignalReceiver(
 
 fun Application.ebmsProviderModule(
     payloadRepository: PayloadRepository,
-    payloadProcessorProvider: () -> PayloadMessageProcessor
+    payloadProcessorProvider: () -> PayloadMessageProcessor,
+    eventRegistrationService: EventRegistrationService
 ) {
     val appMicrometerRegistry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
 
@@ -215,7 +217,7 @@ fun Application.ebmsProviderModule(
         }
         retryErrors(payloadProcessorProvider)
         authenticate(AZURE_AD_AUTH) {
-            getPayloads(payloadRepository)
+            getPayloads(payloadRepository, eventRegistrationService)
         }
     }
 }

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/Routes.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/Routes.kt
@@ -8,12 +8,10 @@ import no.nav.emottak.ebms.async.persistence.repository.PayloadRepository
 import no.nav.emottak.ebms.async.util.EventRegistrationService
 import no.nav.emottak.utils.kafka.model.EventType
 import no.nav.emottak.utils.serialization.toEventDataJson
-import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
 private const val REFERENCE_ID = "referenceId"
 
-@OptIn(ExperimentalUuidApi::class)
 fun Route.getPayloads(
     payloadRepository: PayloadRepository,
     eventRegistrationService: EventRegistrationService

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/Routes.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/Routes.kt
@@ -49,8 +49,8 @@ fun Route.getPayloads(
 
             eventRegistrationService.registerEvent(
                 EventType.ERROR_WHILE_READING_PAYLOAD_FROM_DATABASE,
-                referenceId,
-                Exception("Payload not found for reference ID $referenceId").toEventDataJson()
+                requestId = referenceId.toString(),
+                eventData = Exception("Payload not found for reference ID $referenceId").toEventDataJson()
             )
         } else {
             call.respond(HttpStatusCode.OK, listOfPayloads)
@@ -71,8 +71,8 @@ fun Route.getPayloads(
 
         eventRegistrationService.registerEvent(
             EventType.ERROR_WHILE_READING_PAYLOAD_FROM_DATABASE,
-            referenceId,
-            ex.toEventDataJson()
+            requestId = referenceId.toString(),
+            eventData = ex.toEventDataJson()
         )
     }
     return@get

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/Routes.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/Routes.kt
@@ -5,6 +5,9 @@ import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
 import no.nav.emottak.ebms.async.persistence.repository.PayloadRepository
+import no.nav.emottak.ebms.async.util.EventRegistrationService
+import no.nav.emottak.utils.kafka.model.EventType
+import no.nav.emottak.utils.serialization.toEventDataJson
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
@@ -12,7 +15,8 @@ private const val REFERENCE_ID = "referenceId"
 
 @OptIn(ExperimentalUuidApi::class)
 fun Route.getPayloads(
-    payloadRepository: PayloadRepository
+    payloadRepository: PayloadRepository,
+    eventRegistrationService: EventRegistrationService
 ): Route = get("/api/payloads/{$REFERENCE_ID}") {
     var referenceIdParameter: String? = null
     val referenceId: Uuid?
@@ -42,14 +46,33 @@ fun Route.getPayloads(
 
         if (listOfPayloads.isEmpty()) {
             call.respond(HttpStatusCode.NotFound, "Payload not found for reference ID $referenceId")
+
+            eventRegistrationService.registerEvent(
+                EventType.ERROR_WHILE_READING_PAYLOAD_FROM_DATABASE,
+                referenceId,
+                Exception("Payload not found for reference ID $referenceId").toEventDataJson()
+            )
         } else {
             call.respond(HttpStatusCode.OK, listOfPayloads)
+
+            listOfPayloads.forEach {
+                eventRegistrationService.registerEvent(
+                    EventType.PAYLOAD_READ_FROM_DATABASE,
+                    it
+                )
+            }
         }
     } catch (ex: Exception) {
         log.error("Exception occurred while retrieving Payload: ${ex.localizedMessage} (${ex::class.qualifiedName})")
         call.respond(
             HttpStatusCode.InternalServerError,
             ex.getErrorMessage()
+        )
+
+        eventRegistrationService.registerEvent(
+            EventType.ERROR_WHILE_READING_PAYLOAD_FROM_DATABASE,
+            referenceId,
+            ex.toEventDataJson()
         )
     }
     return@get

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/configuration/Config.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/configuration/Config.kt
@@ -1,8 +1,8 @@
 package no.nav.emottak.ebms.async.configuration
 
-import com.sksamuel.hoplite.Masked
 import no.nav.emottak.utils.config.EventLogging
 import no.nav.emottak.utils.config.Kafka
+import no.nav.emottak.utils.environment.getEnvVar
 import org.apache.kafka.clients.CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG
 import org.apache.kafka.clients.CommonClientConfigs.SECURITY_PROTOCOL_CONFIG
 import org.apache.kafka.common.config.SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG
@@ -14,7 +14,6 @@ import org.apache.kafka.common.config.SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG
 import java.util.Properties
 
 data class Config(
-    val kafkaLocal: KafkaLocal,
     val kafka: Kafka,
     val eventLogging: EventLogging,
     val kafkaSignalReceiver: KafkaSignalReceiver,
@@ -23,21 +22,6 @@ data class Config(
     val kafkaPayloadProducer: KafkaPayloadProducer,
     val kafkaErrorQueue: KafkaErrorQueue
 )
-
-@JvmInline
-value class SecurityProtocol(val value: String)
-
-@JvmInline
-value class KeystoreType(val value: String)
-
-@JvmInline
-value class KeystoreLocation(val value: String)
-
-@JvmInline
-value class TruststoreType(val value: String)
-
-@JvmInline
-value class TruststoreLocation(val value: String)
 
 data class KafkaSignalReceiver(
     val active: Boolean,
@@ -64,36 +48,16 @@ data class KafkaErrorQueue(
     val topic: String
 )
 
-data class KafkaLocal(
-    val bootstrapServers: String,
-    val securityProtocol: SecurityProtocol,
-    val keystoreType: KeystoreType,
-    val keystoreLocation: KeystoreLocation,
-    val keystorePassword: Masked,
-    val truststoreType: TruststoreType,
-    val truststoreLocation: TruststoreLocation,
-    val truststorePassword: Masked,
-    val groupId: String,
-    val properties: Properties = Properties().apply {
-        put(BOOTSTRAP_SERVERS_CONFIG, bootstrapServers)
-        put(SECURITY_PROTOCOL_CONFIG, securityProtocol.value)
-        put(SSL_KEYSTORE_TYPE_CONFIG, keystoreType.value)
-        put(SSL_KEYSTORE_LOCATION_CONFIG, keystoreLocation.value)
-        put(SSL_KEYSTORE_PASSWORD_CONFIG, keystorePassword.value)
-        put(SSL_TRUSTSTORE_TYPE_CONFIG, truststoreType.value)
-        put(SSL_TRUSTSTORE_LOCATION_CONFIG, truststoreLocation.value)
-        put(SSL_TRUSTSTORE_PASSWORD_CONFIG, truststorePassword.value)
-    }
-)
-
-fun KafkaLocal.toProperties() = Properties()
+fun Kafka.toProperties() = Properties()
     .apply {
         put(BOOTSTRAP_SERVERS_CONFIG, bootstrapServers)
-        put(SECURITY_PROTOCOL_CONFIG, securityProtocol.value)
-        put(SSL_KEYSTORE_TYPE_CONFIG, keystoreType.value)
-        put(SSL_KEYSTORE_LOCATION_CONFIG, keystoreLocation.value)
-        put(SSL_KEYSTORE_PASSWORD_CONFIG, keystorePassword.value)
-        put(SSL_TRUSTSTORE_TYPE_CONFIG, truststoreType.value)
-        put(SSL_TRUSTSTORE_LOCATION_CONFIG, truststoreLocation.value)
-        put(SSL_TRUSTSTORE_PASSWORD_CONFIG, truststorePassword.value)
+        if (getEnvVar("NAIS_CLUSTER_NAME", "local") != "local") {
+            put(SECURITY_PROTOCOL_CONFIG, securityProtocol.value)
+            put(SSL_KEYSTORE_TYPE_CONFIG, keystoreType.value)
+            put(SSL_KEYSTORE_LOCATION_CONFIG, keystoreLocation.value)
+            put(SSL_KEYSTORE_PASSWORD_CONFIG, keystorePassword.value)
+            put(SSL_TRUSTSTORE_TYPE_CONFIG, truststoreType.value)
+            put(SSL_TRUSTSTORE_LOCATION_CONFIG, truststoreLocation.value)
+            put(SSL_TRUSTSTORE_PASSWORD_CONFIG, truststorePassword.value)
+        }
     }

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/configuration/Config.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/configuration/Config.kt
@@ -1,6 +1,8 @@
 package no.nav.emottak.ebms.async.configuration
 
 import com.sksamuel.hoplite.Masked
+import no.nav.emottak.utils.config.EventLogging
+import no.nav.emottak.utils.config.Kafka
 import org.apache.kafka.clients.CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG
 import org.apache.kafka.clients.CommonClientConfigs.SECURITY_PROTOCOL_CONFIG
 import org.apache.kafka.common.config.SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG
@@ -12,7 +14,9 @@ import org.apache.kafka.common.config.SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG
 import java.util.Properties
 
 data class Config(
+    val kafkaLocal: KafkaLocal,
     val kafka: Kafka,
+    val eventLogging: EventLogging,
     val kafkaSignalReceiver: KafkaSignalReceiver,
     val kafkaSignalProducer: KafkaSignalProducer,
     val kafkaPayloadReceiver: KafkaPayloadReceiver,
@@ -60,7 +64,7 @@ data class KafkaErrorQueue(
     val topic: String
 )
 
-data class Kafka(
+data class KafkaLocal(
     val bootstrapServers: String,
     val securityProtocol: SecurityProtocol,
     val keystoreType: KeystoreType,
@@ -82,7 +86,7 @@ data class Kafka(
     }
 )
 
-fun Kafka.toProperties() = Properties()
+fun KafkaLocal.toProperties() = Properties()
     .apply {
         put(BOOTSTRAP_SERVERS_CONFIG, bootstrapServers)
         put(SECURITY_PROTOCOL_CONFIG, securityProtocol.value)

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/configuration/Configurator.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/configuration/Configurator.kt
@@ -9,6 +9,7 @@ import com.sksamuel.hoplite.addResourceSource
 fun config() = ConfigLoader.builder()
     .addEnvironmentSource()
     .addResourceSource("/application-personal.conf", optional = true)
+    .addResourceSource("/kafka_common.conf")
     .addResourceSource("/application.conf")
     .withExplicitSealedTypes()
     .build()

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/configuration/Configurator.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/configuration/Configurator.kt
@@ -1,11 +1,9 @@
 package no.nav.emottak.ebms.async.configuration
 
 import com.sksamuel.hoplite.ConfigLoader
-import com.sksamuel.hoplite.ExperimentalHoplite
 import com.sksamuel.hoplite.addEnvironmentSource
 import com.sksamuel.hoplite.addResourceSource
 
-@OptIn(ExperimentalHoplite::class)
 fun config() = ConfigLoader.builder()
     .addEnvironmentSource()
     .addResourceSource("/application-personal.conf", optional = true)

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/kafka/consumer/EbmsPayloadReceiver.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/kafka/consumer/EbmsPayloadReceiver.kt
@@ -5,7 +5,7 @@ import io.github.nomisRev.kafka.receiver.KafkaReceiver
 import io.github.nomisRev.kafka.receiver.ReceiverSettings
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.map
-import no.nav.emottak.ebms.async.configuration.Kafka
+import no.nav.emottak.ebms.async.configuration.KafkaLocal
 import no.nav.emottak.ebms.async.configuration.toProperties
 import no.nav.emottak.ebms.async.log
 import no.nav.emottak.ebms.async.processing.PayloadMessageProcessor
@@ -13,7 +13,7 @@ import org.apache.kafka.common.serialization.ByteArrayDeserializer
 import org.apache.kafka.common.serialization.StringDeserializer
 import kotlin.time.Duration.Companion.seconds
 
-suspend fun startPayloadReceiver(topic: String, kafka: Kafka, payloadMessageProcessor: PayloadMessageProcessor) {
+suspend fun startPayloadReceiver(topic: String, kafka: KafkaLocal, payloadMessageProcessor: PayloadMessageProcessor) {
     log.info("Starting payload message receiver on topic $topic")
     val receiverSettings: ReceiverSettings<String, ByteArray> =
         ReceiverSettings(

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/kafka/consumer/EbmsPayloadReceiver.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/kafka/consumer/EbmsPayloadReceiver.kt
@@ -5,15 +5,15 @@ import io.github.nomisRev.kafka.receiver.KafkaReceiver
 import io.github.nomisRev.kafka.receiver.ReceiverSettings
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.map
-import no.nav.emottak.ebms.async.configuration.KafkaLocal
 import no.nav.emottak.ebms.async.configuration.toProperties
 import no.nav.emottak.ebms.async.log
 import no.nav.emottak.ebms.async.processing.PayloadMessageProcessor
+import no.nav.emottak.utils.config.Kafka
 import org.apache.kafka.common.serialization.ByteArrayDeserializer
 import org.apache.kafka.common.serialization.StringDeserializer
 import kotlin.time.Duration.Companion.seconds
 
-suspend fun startPayloadReceiver(topic: String, kafka: KafkaLocal, payloadMessageProcessor: PayloadMessageProcessor) {
+suspend fun startPayloadReceiver(topic: String, kafka: Kafka, payloadMessageProcessor: PayloadMessageProcessor) {
     log.info("Starting payload message receiver on topic $topic")
     val receiverSettings: ReceiverSettings<String, ByteArray> =
         ReceiverSettings(

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/kafka/consumer/EbmsSignalReceiver.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/kafka/consumer/EbmsSignalReceiver.kt
@@ -5,7 +5,7 @@ import io.github.nomisRev.kafka.receiver.KafkaReceiver
 import io.github.nomisRev.kafka.receiver.ReceiverSettings
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.map
-import no.nav.emottak.ebms.async.configuration.Kafka
+import no.nav.emottak.ebms.async.configuration.KafkaLocal
 import no.nav.emottak.ebms.async.configuration.toProperties
 import no.nav.emottak.ebms.async.log
 import no.nav.emottak.ebms.async.processing.SignalProcessor
@@ -13,7 +13,7 @@ import org.apache.kafka.common.serialization.ByteArrayDeserializer
 import org.apache.kafka.common.serialization.StringDeserializer
 import kotlin.time.Duration.Companion.seconds
 
-suspend fun startSignalReceiver(topic: String, kafka: Kafka, signalProcessor: SignalProcessor) {
+suspend fun startSignalReceiver(topic: String, kafka: KafkaLocal, signalProcessor: SignalProcessor) {
     log.info("Starting signal message receiver on topic $topic")
     val receiverSettings: ReceiverSettings<String, ByteArray> =
         ReceiverSettings(

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/kafka/consumer/EbmsSignalReceiver.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/kafka/consumer/EbmsSignalReceiver.kt
@@ -5,15 +5,15 @@ import io.github.nomisRev.kafka.receiver.KafkaReceiver
 import io.github.nomisRev.kafka.receiver.ReceiverSettings
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.map
-import no.nav.emottak.ebms.async.configuration.KafkaLocal
 import no.nav.emottak.ebms.async.configuration.toProperties
 import no.nav.emottak.ebms.async.log
 import no.nav.emottak.ebms.async.processing.SignalProcessor
+import no.nav.emottak.utils.config.Kafka
 import org.apache.kafka.common.serialization.ByteArrayDeserializer
 import org.apache.kafka.common.serialization.StringDeserializer
 import kotlin.time.Duration.Companion.seconds
 
-suspend fun startSignalReceiver(topic: String, kafka: KafkaLocal, signalProcessor: SignalProcessor) {
+suspend fun startSignalReceiver(topic: String, kafka: Kafka, signalProcessor: SignalProcessor) {
     log.info("Starting signal message receiver on topic $topic")
     val receiverSettings: ReceiverSettings<String, ByteArray> =
         ReceiverSettings(

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/kafka/consumer/FailedMessageKafkaHandler.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/kafka/consumer/FailedMessageKafkaHandler.kt
@@ -15,8 +15,8 @@ import kotlinx.coroutines.flow.cancellable
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
-import no.nav.emottak.ebms.async.configuration.Kafka
 import no.nav.emottak.ebms.async.configuration.KafkaErrorQueue
+import no.nav.emottak.ebms.async.configuration.KafkaLocal
 import no.nav.emottak.ebms.async.configuration.config
 import no.nav.emottak.ebms.async.processing.PayloadMessageProcessor
 import org.apache.kafka.clients.consumer.ConsumerRecord
@@ -42,7 +42,7 @@ val logger = LoggerFactory.getLogger(FailedMessageKafkaHandler::class.java)
 
 class FailedMessageKafkaHandler(
     val kafkaErrorQueue: KafkaErrorQueue = config().kafkaErrorQueue,
-    kafka: Kafka = config().kafka
+    kafka: KafkaLocal = config().kafkaLocal
 ) {
 
     val publisher = KafkaPublisher(
@@ -159,12 +159,12 @@ fun ReceiverRecord<String, ByteArray>.addHeader(key: String, value: String) {
 }
 
 fun getRetryRecord(fromOffset: Long = 0, requestedRecords: Int = 1): ReceiverRecord<String, ByteArray>? {
-    return getRecord(config().kafkaErrorQueue.topic, config().kafka, fromOffset, requestedRecords)
+    return getRecord(config().kafkaErrorQueue.topic, config().kafkaLocal, fromOffset, requestedRecords)
 }
 
 fun getRecord(
     topic: String,
-    kafka: Kafka,
+    kafka: KafkaLocal,
     fromOffset: Long = 0,
     requestedRecords: Int = 1
 ): ReceiverRecord<String, ByteArray>? {
@@ -173,7 +173,7 @@ fun getRecord(
 
 fun getRecords(
     topic: String,
-    kafka: Kafka,
+    kafka: KafkaLocal,
     fromOffset: Long = 0,
     requestedRecords: Int = 1
 ): List<ReceiverRecord<String, ByteArray>> {

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/kafka/producer/EbmsMessageProducer.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/kafka/producer/EbmsMessageProducer.kt
@@ -3,15 +3,15 @@ package no.nav.emottak.ebms.async.kafka.producer
 import io.github.nomisRev.kafka.publisher.Acks
 import io.github.nomisRev.kafka.publisher.KafkaPublisher
 import io.github.nomisRev.kafka.publisher.PublisherSettings
-import no.nav.emottak.ebms.async.configuration.KafkaLocal
 import no.nav.emottak.ebms.async.configuration.toProperties
+import no.nav.emottak.utils.config.Kafka
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.clients.producer.RecordMetadata
 import org.apache.kafka.common.serialization.ByteArraySerializer
 import org.apache.kafka.common.serialization.StringSerializer
 import org.slf4j.LoggerFactory
 
-class EbmsMessageProducer(private val topic: String, kafka: KafkaLocal) {
+class EbmsMessageProducer(private val topic: String, kafka: Kafka) {
     private val log = LoggerFactory.getLogger("no.nav.emottak.ebms.messaging")
 
     private val kafkaPublisher = KafkaPublisher(

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/kafka/producer/EbmsMessageProducer.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/kafka/producer/EbmsMessageProducer.kt
@@ -3,7 +3,7 @@ package no.nav.emottak.ebms.async.kafka.producer
 import io.github.nomisRev.kafka.publisher.Acks
 import io.github.nomisRev.kafka.publisher.KafkaPublisher
 import io.github.nomisRev.kafka.publisher.PublisherSettings
-import no.nav.emottak.ebms.async.configuration.Kafka
+import no.nav.emottak.ebms.async.configuration.KafkaLocal
 import no.nav.emottak.ebms.async.configuration.toProperties
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.clients.producer.RecordMetadata
@@ -11,7 +11,7 @@ import org.apache.kafka.common.serialization.ByteArraySerializer
 import org.apache.kafka.common.serialization.StringSerializer
 import org.slf4j.LoggerFactory
 
-class EbmsMessageProducer(private val topic: String, kafka: Kafka) {
+class EbmsMessageProducer(private val topic: String, kafka: KafkaLocal) {
     private val log = LoggerFactory.getLogger("no.nav.emottak.ebms.messaging")
 
     private val kafkaPublisher = KafkaPublisher(

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/persistence/repository/EbmsMessageDetailsRepository.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/persistence/repository/EbmsMessageDetailsRepository.kt
@@ -23,12 +23,10 @@ import org.jetbrains.exposed.sql.transactions.transaction
 import org.jetbrains.exposed.sql.upsert
 import org.slf4j.LoggerFactory
 import java.sql.SQLException
-import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 import kotlin.uuid.toJavaUuid
 import kotlin.uuid.toKotlinUuid
 
-@OptIn(ExperimentalUuidApi::class)
 class EbmsMessageDetailsRepository(private val database: Database) {
 
     private val log = LoggerFactory.getLogger(EbmsMessageDetailsRepository::class.java)
@@ -128,7 +126,6 @@ class EbmsMessageDetailsRepository(private val database: Database) {
         }
     }
 
-    @OptIn(ExperimentalUuidApi::class)
     fun saveEbmsMessage(
         ebmsMessage: EbmsMessage
     ) {

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/persistence/repository/EventsRepository.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/persistence/repository/EventsRepository.kt
@@ -15,12 +15,10 @@ import no.nav.emottak.message.model.Event
 import no.nav.emottak.message.model.log
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.jetbrains.exposed.sql.upsert
-import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 import kotlin.uuid.toJavaUuid
 import kotlin.uuid.toKotlinUuid
 
-@OptIn(ExperimentalUuidApi::class)
 class EventsRepository(private val database: Database) {
 
     fun updateOrInsert(event: Event): Uuid {
@@ -64,7 +62,6 @@ class EventsRepository(private val database: Database) {
     }
 }
 
-@OptIn(ExperimentalUuidApi::class)
 fun EbmsMessage.saveEvent(message: String, eventsRepository: EventsRepository) {
     log.info(this.marker(), message)
     eventsRepository.updateOrInsert(

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/persistence/repository/PayloadRepository.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/persistence/repository/PayloadRepository.kt
@@ -7,12 +7,10 @@ import no.nav.emottak.ebms.async.persistence.table.PayloadTable.referenceId
 import no.nav.emottak.message.model.AsyncPayload
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.jetbrains.exposed.sql.upsert
-import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
 class PayloadRepository(private val database: Database) {
 
-    @OptIn(ExperimentalUuidApi::class)
     fun updateOrInsert(payload: AsyncPayload): Uuid {
         transaction(database.db) {
             PayloadTable.upsert(referenceId, contentId) {
@@ -25,7 +23,6 @@ class PayloadRepository(private val database: Database) {
         return Uuid.parse(payload.referenceId)
     }
 
-    @OptIn(ExperimentalUuidApi::class)
     fun getByReferenceId(referenceId: Uuid): List<AsyncPayload> {
         return transaction(database.db) {
             PayloadTable

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/processing/PayloadMessageProcessor.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/processing/PayloadMessageProcessor.kt
@@ -26,6 +26,7 @@ import no.nav.emottak.message.xml.getDocumentBuilder
 import no.nav.emottak.util.marker
 import no.nav.emottak.utils.kafka.model.EventDataType
 import no.nav.emottak.utils.kafka.model.EventType
+import no.nav.emottak.utils.serialization.toEventDataJson
 import java.io.ByteArrayInputStream
 
 class PayloadMessageProcessor(
@@ -59,14 +60,31 @@ class PayloadMessageProcessor(
         return ebmsMessage as PayloadMessage
     }
 
-    private suspend fun retrievePayloads(reference: String) =
-        smtpTransportClient.getPayload(reference).map {
-            Payload(
-                bytes = it.content,
-                contentId = it.contentId,
-                contentType = it.contentType
+    private suspend fun retrievePayloads(reference: String): List<Payload> {
+        try {
+            return smtpTransportClient.getPayload(reference).map {
+                Payload(
+                    bytes = it.content,
+                    contentId = it.contentId,
+                    contentType = it.contentType
+                )
+            }.onEach {
+                eventRegistrationService.registerEvent(
+                    EventType.PAYLOAD_RECEIVED_VIA_HTTP,
+                    requestId = reference,
+                    contentId = it.contentId
+                )
+            }
+        } catch (e: Exception) {
+            log.error("Error occurred while retrieving payloads for referenceId: $reference", e)
+            eventRegistrationService.registerEvent(
+                EventType.ERROR_WHILE_RECEIVING_PAYLOAD_VIA_HTTP,
+                requestId = reference,
+                eventData = e.toEventDataJson()
             )
+            throw e
         }
+    }
 
     private suspend fun processPayloadMessage(
         ebmsPayloadMessage: PayloadMessage,

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/processing/PayloadMessageProcessor.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/processing/PayloadMessageProcessor.kt
@@ -92,7 +92,7 @@ class PayloadMessageProcessor(
     ) {
         try {
             val eventData = Json.encodeToString(
-                mapOf(EventDataType.QUEUE_NAME to config().kafkaPayloadReceiver.topic)
+                mapOf(EventDataType.QUEUE_NAME.value to config().kafkaPayloadReceiver.topic)
             )
             eventRegistrationService.registerEvent(
                 EventType.MESSAGE_READ_FROM_QUEUE,

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/processing/PayloadMessageResponder.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/processing/PayloadMessageResponder.kt
@@ -22,7 +22,6 @@ import no.nav.emottak.message.xml.asByteArray
 import no.nav.emottak.utils.kafka.model.EventDataType
 import no.nav.emottak.utils.kafka.model.EventType
 import no.nav.emottak.utils.serialization.toEventDataJson
-import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
 class PayloadMessageResponder(
@@ -35,7 +34,6 @@ class PayloadMessageResponder(
     val eventRegistrationService: EventRegistrationService
 ) {
 
-    @OptIn(ExperimentalUuidApi::class)
     suspend fun respond(payloadMessage: PayloadMessage) {
         try {
             sendInService.sendIn(payloadMessage).let { sendInResponse ->
@@ -103,7 +101,6 @@ class PayloadMessageResponder(
         }
     }
 
-    @OptIn(ExperimentalUuidApi::class)
     suspend fun savePayloadsToDatabase(
         document: EbMSDocument,
         payloadMessage: PayloadMessage

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/processing/PayloadMessageResponder.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/processing/PayloadMessageResponder.kt
@@ -61,7 +61,7 @@ class PayloadMessageResponder(
 
                         ebmsPayloadProducer.publishMessage(it.requestId, it.dokument.asByteArray()).onSuccess {
                             val eventData = Json.encodeToString(
-                                mapOf(EventDataType.QUEUE_NAME to config().kafkaPayloadProducer.topic)
+                                mapOf(EventDataType.QUEUE_NAME.value to config().kafkaPayloadProducer.topic)
                             )
                             eventRegistrationService.registerEvent(
                                 EventType.MESSAGE_PLACED_IN_QUEUE,
@@ -71,8 +71,8 @@ class PayloadMessageResponder(
                         }.onFailure {
                             val eventData = Json.encodeToString(
                                 mapOf(
-                                    EventDataType.QUEUE_NAME to config().kafkaPayloadProducer.topic,
-                                    EventDataType.ERROR_MESSAGE to it.message
+                                    EventDataType.QUEUE_NAME.value to config().kafkaPayloadProducer.topic,
+                                    EventDataType.ERROR_MESSAGE.value to it.message
                                 )
                             )
                             eventRegistrationService.registerEvent(
@@ -89,8 +89,8 @@ class PayloadMessageResponder(
 
             val eventData = Json.encodeToString(
                 mapOf(
-                    EventDataType.QUEUE_NAME to config().kafkaPayloadProducer.topic,
-                    EventDataType.ERROR_MESSAGE to e.message
+                    EventDataType.QUEUE_NAME.value to config().kafkaPayloadProducer.topic,
+                    EventDataType.ERROR_MESSAGE.value to e.message
                 )
             )
             eventRegistrationService.registerEvent(

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/processing/SignalProcessor.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/processing/SignalProcessor.kt
@@ -12,14 +12,12 @@ import no.nav.emottak.message.model.MessageError
 import no.nav.emottak.message.model.toEbmsMessageDetails
 import no.nav.emottak.message.xml.getDocumentBuilder
 import java.io.ByteArrayInputStream
-import kotlin.uuid.ExperimentalUuidApi
 
 class SignalProcessor(
     val ebmsMessageDetailsRepository: EbmsMessageDetailsRepository,
     val cpaValidationService: CPAValidationService
 ) {
 
-    @OptIn(ExperimentalUuidApi::class)
     suspend fun processSignal(requestId: String, content: ByteArray) {
         try {
             val ebxmlSignalMessage = createEbmsMessage(requestId, content)

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/util/EventRegistration.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/util/EventRegistration.kt
@@ -7,7 +7,6 @@ import no.nav.emottak.utils.common.parseOrGenerateUuid
 import no.nav.emottak.utils.kafka.model.Event
 import no.nav.emottak.utils.kafka.model.EventType
 import no.nav.emottak.utils.kafka.service.EventLoggingService
-import kotlin.uuid.ExperimentalUuidApi
 
 interface EventRegistrationService {
     suspend fun registerEvent(
@@ -34,7 +33,6 @@ class EventRegistrationServiceImpl(
     private val eventLoggingService: EventLoggingService
 ) : EventRegistrationService {
 
-    @OptIn(ExperimentalUuidApi::class)
     override suspend fun registerEvent(
         eventType: EventType,
         payloadMessage: PayloadMessage,
@@ -51,7 +49,6 @@ class EventRegistrationServiceImpl(
         )
     }
 
-    @OptIn(ExperimentalUuidApi::class)
     override suspend fun registerEvent(
         eventType: EventType,
         asyncPayload: AsyncPayload,
@@ -68,7 +65,6 @@ class EventRegistrationServiceImpl(
         )
     }
 
-    @OptIn(ExperimentalUuidApi::class)
     override suspend fun registerEvent(
         eventType: EventType,
         requestId: String,

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/util/EventRegistration.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/util/EventRegistration.kt
@@ -1,7 +1,7 @@
 package no.nav.emottak.ebms.async.util
 
 import no.nav.emottak.ebms.async.log
-import no.nav.emottak.message.model.ValidationRequest
+import no.nav.emottak.message.model.PayloadMessage
 import no.nav.emottak.utils.common.parseOrGenerateUuid
 import no.nav.emottak.utils.kafka.model.Event
 import no.nav.emottak.utils.kafka.model.EventType
@@ -11,8 +11,7 @@ import kotlin.uuid.ExperimentalUuidApi
 interface EventRegistrationService {
     suspend fun registerEvent(
         eventType: EventType,
-        validationRequest: ValidationRequest,
-        requestId: String,
+        payloadMessage: PayloadMessage,
         eventData: String = "{}"
     )
 }
@@ -23,18 +22,17 @@ class EventRegistrationServiceImpl(
     @OptIn(ExperimentalUuidApi::class)
     override suspend fun registerEvent(
         eventType: EventType,
-        validationRequest: ValidationRequest,
-        requestId: String,
+        payloadMessage: PayloadMessage,
         eventData: String
     ) {
-        log.debug("Registering event for requestId: $requestId")
+        log.debug("Registering event for requestId: ${payloadMessage.requestId}")
 
         try {
             val event = Event(
                 eventType = eventType,
-                requestId = requestId.parseOrGenerateUuid(),
-                contentId = "",
-                messageId = validationRequest.messageId,
+                requestId = payloadMessage.requestId.parseOrGenerateUuid(),
+                contentId = payloadMessage.payload.contentId,
+                messageId = payloadMessage.messageId,
                 eventData = eventData
             )
             log.debug("Registering event: {}", event)
@@ -50,10 +48,9 @@ class EventRegistrationServiceImpl(
 class EventRegistrationServiceFake : EventRegistrationService {
     override suspend fun registerEvent(
         eventType: EventType,
-        validationRequest: ValidationRequest,
-        requestId: String,
+        payloadMessage: PayloadMessage,
         eventData: String
     ) {
-        log.debug("Registering event $eventType for validationRequest: $validationRequest and eventData: $eventData")
+        log.debug("Registering event $eventType for payloadMessage: $payloadMessage and eventData: $eventData")
     }
 }

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/util/EventRegistration.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/util/EventRegistration.kt
@@ -40,23 +40,15 @@ class EventRegistrationServiceImpl(
         payloadMessage: PayloadMessage,
         eventData: String
     ) {
-        log.debug("Registering event for requestId: ${payloadMessage.requestId}")
-
-        try {
-            val event = Event(
+        registerEvent(
+            Event(
                 eventType = eventType,
                 requestId = payloadMessage.requestId.parseOrGenerateUuid(),
                 contentId = payloadMessage.payload.contentId,
                 messageId = payloadMessage.messageId,
                 eventData = eventData
             )
-            log.debug("Registering event: {}", event)
-
-            eventLoggingService.logEvent(event)
-            log.debug("Event is registered successfully")
-        } catch (e: Exception) {
-            log.error("Error while registering event: ${e.message}", e)
-        }
+        )
     }
 
     @OptIn(ExperimentalUuidApi::class)
@@ -65,23 +57,15 @@ class EventRegistrationServiceImpl(
         asyncPayload: AsyncPayload,
         eventData: String
     ) {
-        log.debug("Registering event for requestId: ${asyncPayload.referenceId}")
-
-        try {
-            val event = Event(
+        registerEvent(
+            Event(
                 eventType = eventType,
                 requestId = asyncPayload.referenceId.parseOrGenerateUuid(),
                 contentId = asyncPayload.contentId,
                 messageId = "",
                 eventData = eventData
             )
-            log.debug("Registering event: {}", event)
-
-            eventLoggingService.logEvent(event)
-            log.debug("Event is registered successfully")
-        } catch (e: Exception) {
-            log.error("Error while registering event: ${e.message}", e)
-        }
+        )
     }
 
     @OptIn(ExperimentalUuidApi::class)
@@ -91,18 +75,20 @@ class EventRegistrationServiceImpl(
         contentId: String,
         eventData: String
     ) {
-        log.debug("Registering event for requestId: $requestId")
-
-        try {
-            val event = Event(
+        registerEvent(
+            Event(
                 eventType = eventType,
                 requestId = requestId.parseOrGenerateUuid(),
                 contentId = contentId,
                 messageId = "",
                 eventData = eventData
             )
-            log.debug("Registering event: {}", event)
+        )
+    }
 
+    private suspend fun registerEvent(event: Event) {
+        try {
+            log.debug("Registering event: {}", event)
             eventLoggingService.logEvent(event)
             log.debug("Event is registered successfully")
         } catch (e: Exception) {

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/util/EventRegistration.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/util/EventRegistration.kt
@@ -8,7 +8,6 @@ import no.nav.emottak.utils.kafka.model.Event
 import no.nav.emottak.utils.kafka.model.EventType
 import no.nav.emottak.utils.kafka.service.EventLoggingService
 import kotlin.uuid.ExperimentalUuidApi
-import kotlin.uuid.Uuid
 
 interface EventRegistrationService {
     suspend fun registerEvent(
@@ -23,10 +22,10 @@ interface EventRegistrationService {
         eventData: String = "{}"
     )
 
-    @OptIn(ExperimentalUuidApi::class)
     suspend fun registerEvent(
         eventType: EventType,
-        requestId: Uuid,
+        requestId: String,
+        contentId: String = "",
         eventData: String = "{}"
     )
 }
@@ -88,7 +87,8 @@ class EventRegistrationServiceImpl(
     @OptIn(ExperimentalUuidApi::class)
     override suspend fun registerEvent(
         eventType: EventType,
-        requestId: Uuid,
+        requestId: String,
+        contentId: String,
         eventData: String
     ) {
         log.debug("Registering event for requestId: $requestId")
@@ -96,8 +96,8 @@ class EventRegistrationServiceImpl(
         try {
             val event = Event(
                 eventType = eventType,
-                requestId = requestId,
-                contentId = "",
+                requestId = requestId.parseOrGenerateUuid(),
+                contentId = contentId,
                 messageId = "",
                 eventData = eventData
             )
@@ -128,10 +128,10 @@ class EventRegistrationServiceFake : EventRegistrationService {
         log.debug("Registering event $eventType for asyncPayload: $asyncPayload and eventData: $eventData")
     }
 
-    @OptIn(ExperimentalUuidApi::class)
     override suspend fun registerEvent(
         eventType: EventType,
-        requestId: Uuid,
+        requestId: String,
+        contentId: String,
         eventData: String
     ) {
         log.debug("Registering event $eventType for requestId: $requestId and eventData: $eventData")

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/util/EventRegistration.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/util/EventRegistration.kt
@@ -1,0 +1,59 @@
+package no.nav.emottak.ebms.async.util
+
+import no.nav.emottak.ebms.async.log
+import no.nav.emottak.message.model.ValidationRequest
+import no.nav.emottak.utils.common.parseOrGenerateUuid
+import no.nav.emottak.utils.kafka.model.Event
+import no.nav.emottak.utils.kafka.model.EventType
+import no.nav.emottak.utils.kafka.service.EventLoggingService
+import kotlin.uuid.ExperimentalUuidApi
+
+interface EventRegistrationService {
+    suspend fun registerEvent(
+        eventType: EventType,
+        validationRequest: ValidationRequest,
+        requestId: String,
+        eventData: String = "{}"
+    )
+}
+
+class EventRegistrationServiceImpl(
+    private val eventLoggingService: EventLoggingService
+) : EventRegistrationService {
+    @OptIn(ExperimentalUuidApi::class)
+    override suspend fun registerEvent(
+        eventType: EventType,
+        validationRequest: ValidationRequest,
+        requestId: String,
+        eventData: String
+    ) {
+        log.debug("Registering event for requestId: $requestId")
+
+        try {
+            val event = Event(
+                eventType = eventType,
+                requestId = requestId.parseOrGenerateUuid(),
+                contentId = "",
+                messageId = validationRequest.messageId,
+                eventData = eventData
+            )
+            log.debug("Registering event: {}", event)
+
+            eventLoggingService.logEvent(event)
+            log.debug("Event is registered successfully")
+        } catch (e: Exception) {
+            log.error("Error while registering event: ${e.message}", e)
+        }
+    }
+}
+
+class EventRegistrationServiceFake : EventRegistrationService {
+    override suspend fun registerEvent(
+        eventType: EventType,
+        validationRequest: ValidationRequest,
+        requestId: String,
+        eventData: String
+    ) {
+        log.debug("Registering event $eventType for validationRequest: $validationRequest and eventData: $eventData")
+    }
+}

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/util/EventRegistration.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/util/EventRegistration.kt
@@ -1,12 +1,14 @@
 package no.nav.emottak.ebms.async.util
 
 import no.nav.emottak.ebms.async.log
+import no.nav.emottak.message.model.AsyncPayload
 import no.nav.emottak.message.model.PayloadMessage
 import no.nav.emottak.utils.common.parseOrGenerateUuid
 import no.nav.emottak.utils.kafka.model.Event
 import no.nav.emottak.utils.kafka.model.EventType
 import no.nav.emottak.utils.kafka.service.EventLoggingService
 import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 
 interface EventRegistrationService {
     suspend fun registerEvent(
@@ -14,11 +16,25 @@ interface EventRegistrationService {
         payloadMessage: PayloadMessage,
         eventData: String = "{}"
     )
+
+    suspend fun registerEvent(
+        eventType: EventType,
+        asyncPayload: AsyncPayload,
+        eventData: String = "{}"
+    )
+
+    @OptIn(ExperimentalUuidApi::class)
+    suspend fun registerEvent(
+        eventType: EventType,
+        requestId: Uuid,
+        eventData: String = "{}"
+    )
 }
 
 class EventRegistrationServiceImpl(
     private val eventLoggingService: EventLoggingService
 ) : EventRegistrationService {
+
     @OptIn(ExperimentalUuidApi::class)
     override suspend fun registerEvent(
         eventType: EventType,
@@ -43,6 +59,56 @@ class EventRegistrationServiceImpl(
             log.error("Error while registering event: ${e.message}", e)
         }
     }
+
+    @OptIn(ExperimentalUuidApi::class)
+    override suspend fun registerEvent(
+        eventType: EventType,
+        asyncPayload: AsyncPayload,
+        eventData: String
+    ) {
+        log.debug("Registering event for requestId: ${asyncPayload.referenceId}")
+
+        try {
+            val event = Event(
+                eventType = eventType,
+                requestId = asyncPayload.referenceId.parseOrGenerateUuid(),
+                contentId = asyncPayload.contentId,
+                messageId = "",
+                eventData = eventData
+            )
+            log.debug("Registering event: {}", event)
+
+            eventLoggingService.logEvent(event)
+            log.debug("Event is registered successfully")
+        } catch (e: Exception) {
+            log.error("Error while registering event: ${e.message}", e)
+        }
+    }
+
+    @OptIn(ExperimentalUuidApi::class)
+    override suspend fun registerEvent(
+        eventType: EventType,
+        requestId: Uuid,
+        eventData: String
+    ) {
+        log.debug("Registering event for requestId: $requestId")
+
+        try {
+            val event = Event(
+                eventType = eventType,
+                requestId = requestId,
+                contentId = "",
+                messageId = "",
+                eventData = eventData
+            )
+            log.debug("Registering event: {}", event)
+
+            eventLoggingService.logEvent(event)
+            log.debug("Event is registered successfully")
+        } catch (e: Exception) {
+            log.error("Error while registering event: ${e.message}", e)
+        }
+    }
 }
 
 class EventRegistrationServiceFake : EventRegistrationService {
@@ -52,5 +118,22 @@ class EventRegistrationServiceFake : EventRegistrationService {
         eventData: String
     ) {
         log.debug("Registering event $eventType for payloadMessage: $payloadMessage and eventData: $eventData")
+    }
+
+    override suspend fun registerEvent(
+        eventType: EventType,
+        asyncPayload: AsyncPayload,
+        eventData: String
+    ) {
+        log.debug("Registering event $eventType for asyncPayload: $asyncPayload and eventData: $eventData")
+    }
+
+    @OptIn(ExperimentalUuidApi::class)
+    override suspend fun registerEvent(
+        eventType: EventType,
+        requestId: Uuid,
+        eventData: String
+    ) {
+        log.debug("Registering event $eventType for requestId: $requestId and eventData: $eventData")
     }
 }

--- a/ebms-async/src/main/resources/application.conf
+++ b/ebms-async/src/main/resources/application.conf
@@ -1,5 +1,5 @@
 
-kafka {
+kafkaLocal {
   bootstrapServers = "${KAFKA_BROKERS:-http://localhost:9092}"
   securityProtocol = "SSL"
   keystoreType = "PKCS12"
@@ -8,6 +8,10 @@ kafka {
   truststoreType = "JKS"
   truststoreLocation = "${KAFKA_TRUSTSTORE_PATH:-}"
   truststorePassword = "${KAFKA_CREDSTORE_PASSWORD:-}"
+  groupId = "ebms-async"
+}
+
+kafka {
   groupId = "ebms-async"
 }
 

--- a/ebms-async/src/test/kotlin/no/nav/emottak/ebms/async/EbmsRouteAsyncIT.kt
+++ b/ebms-async/src/test/kotlin/no/nav/emottak/ebms/async/EbmsRouteAsyncIT.kt
@@ -31,7 +31,6 @@ import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.xmlsoap.schemas.soap.envelope.Envelope
-import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation as ClientContentNegotiation
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation as ServerContentNegotiation
@@ -60,7 +59,6 @@ class EbmsRouteAsyncIT {
         testBlock()
     }
 
-    @OptIn(ExperimentalUuidApi::class)
     @Test
     fun `Payload endpoint returns list of payloads`() = validationTestApp {
         val validReferenceId = Uuid.random()
@@ -100,7 +98,6 @@ class EbmsRouteAsyncIT {
         assertEquals(2, listOfPayloads.size)
     }
 
-    @OptIn(ExperimentalUuidApi::class)
     @Test
     fun `Payload endpoint returns 404 Not Found when no payload is found`() = validationTestApp {
         val validReferenceId = Uuid.random()

--- a/ebms-async/src/test/kotlin/no/nav/emottak/ebms/async/EbmsRouteAsyncIT.kt
+++ b/ebms-async/src/test/kotlin/no/nav/emottak/ebms/async/EbmsRouteAsyncIT.kt
@@ -18,6 +18,7 @@ import io.mockk.every
 import io.mockk.mockk
 import no.nav.emottak.ebms.async.kafka.KafkaTestContainer
 import no.nav.emottak.ebms.async.persistence.repository.PayloadRepository
+import no.nav.emottak.ebms.async.util.EventRegistrationServiceFake
 import no.nav.emottak.ebms.configuration.config
 import no.nav.emottak.message.ebxml.acknowledgment
 import no.nav.emottak.message.ebxml.messageHeader
@@ -38,6 +39,7 @@ import io.ktor.server.plugins.contentnegotiation.ContentNegotiation as ServerCon
 class EbmsRouteAsyncIT {
 
     val payloadRepository = mockk<PayloadRepository>()
+    val eventRegistrationService = EventRegistrationServiceFake()
 
     fun <T> validationTestApp(testBlock: suspend ApplicationTestBuilder.() -> T) = testApplication {
         application {
@@ -51,7 +53,7 @@ class EbmsRouteAsyncIT {
 
             routing {
                 authenticate(AZURE_AD_AUTH) {
-                    getPayloads(payloadRepository)
+                    getPayloads(payloadRepository, eventRegistrationService)
                 }
             }
         }

--- a/ebms-async/src/test/kotlin/no/nav/emottak/ebms/async/kafka/ErrorHandlerTest.kt
+++ b/ebms-async/src/test/kotlin/no/nav/emottak/ebms/async/kafka/ErrorHandlerTest.kt
@@ -11,11 +11,9 @@ import no.nav.emottak.ebms.async.kafka.consumer.RETRY_COUNT_HEADER
 import no.nav.emottak.ebms.async.kafka.consumer.asReceiverRecord
 import no.nav.emottak.ebms.async.kafka.consumer.getRecord
 import no.nav.emottak.ebms.async.processing.PayloadMessageProcessor
-import org.apache.kafka.clients.CommonClientConfigs
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
-import java.util.Properties
 
 class ErrorHandlerTest {
 
@@ -28,11 +26,8 @@ class ErrorHandlerTest {
             KafkaTestContainer.createTopic(config().kafkaPayloadProducer.topic)
 
             val testcontainerKafkaConfig =
-                config().kafkaLocal.copy(
-                    bootstrapServers = KafkaTestContainer.kafkaContainer.bootstrapServers,
-                    properties = Properties().apply {
-                        put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, KafkaTestContainer.kafkaContainer.bootstrapServers)
-                    }
+                config().kafka.copy(
+                    bootstrapServers = KafkaTestContainer.kafkaContainer.bootstrapServers
                 )
 
             val errorHandler = FailedMessageKafkaHandler(

--- a/ebms-async/src/test/kotlin/no/nav/emottak/ebms/async/kafka/ErrorHandlerTest.kt
+++ b/ebms-async/src/test/kotlin/no/nav/emottak/ebms/async/kafka/ErrorHandlerTest.kt
@@ -28,7 +28,7 @@ class ErrorHandlerTest {
             KafkaTestContainer.createTopic(config().kafkaPayloadProducer.topic)
 
             val testcontainerKafkaConfig =
-                config().kafka.copy(
+                config().kafkaLocal.copy(
                     bootstrapServers = KafkaTestContainer.kafkaContainer.bootstrapServers,
                     properties = Properties().apply {
                         put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, KafkaTestContainer.kafkaContainer.bootstrapServers)

--- a/ebms-async/src/test/kotlin/no/nav/emottak/ebms/async/kafka/KafkaIntegrationTest.kt
+++ b/ebms-async/src/test/kotlin/no/nav/emottak/ebms/async/kafka/KafkaIntegrationTest.kt
@@ -42,7 +42,7 @@ class KafkaIntegrationTest {
         if (noLocalKafkaEnv()) return
         val record = getRecord(
             kafkaConfig.kafkaPayloadReceiver.topic,
-            kafkaConfig.kafka
+            kafkaConfig.kafkaLocal
         )
         assert(
             record?.key() != null
@@ -58,7 +58,7 @@ class KafkaIntegrationTest {
                 fromOffset = 9379942,
                 topic = kafkaConfig.kafkaPayloadReceiver.topic,
                 requestedRecords = 2,
-                kafka = kafkaConfig.kafka
+                kafka = kafkaConfig.kafkaLocal
             )!!
             runBlocking {
                 failedMessageQueue.sendToRetry(

--- a/ebms-async/src/test/kotlin/no/nav/emottak/ebms/async/kafka/KafkaIntegrationTest.kt
+++ b/ebms-async/src/test/kotlin/no/nav/emottak/ebms/async/kafka/KafkaIntegrationTest.kt
@@ -42,7 +42,7 @@ class KafkaIntegrationTest {
         if (noLocalKafkaEnv()) return
         val record = getRecord(
             kafkaConfig.kafkaPayloadReceiver.topic,
-            kafkaConfig.kafkaLocal
+            kafkaConfig.kafka
         )
         assert(
             record?.key() != null
@@ -58,7 +58,7 @@ class KafkaIntegrationTest {
                 fromOffset = 9379942,
                 topic = kafkaConfig.kafkaPayloadReceiver.topic,
                 requestedRecords = 2,
-                kafka = kafkaConfig.kafkaLocal
+                kafka = kafkaConfig.kafka
             )!!
             runBlocking {
                 failedMessageQueue.sendToRetry(

--- a/ebms-async/src/test/kotlin/no/nav/emottak/ebms/async/persistence/EbmsMessageDetailsRepositoryTest.kt
+++ b/ebms-async/src/test/kotlin/no/nav/emottak/ebms/async/persistence/EbmsMessageDetailsRepositoryTest.kt
@@ -17,9 +17,7 @@ import org.junit.jupiter.api.Test
 import org.testcontainers.containers.PostgreSQLContainer
 import java.sql.DriverManager
 import java.time.Instant
-import kotlin.uuid.ExperimentalUuidApi
 
-@OptIn(ExperimentalUuidApi::class)
 class EbmsMessageDetailsRepositoryTest {
     companion object {
         lateinit var ebmsMessageDetailsRepository: EbmsMessageDetailsRepository

--- a/ebms-async/src/test/kotlin/no/nav/emottak/ebms/async/persistence/EventsRepositoryTest.kt
+++ b/ebms-async/src/test/kotlin/no/nav/emottak/ebms/async/persistence/EventsRepositoryTest.kt
@@ -18,10 +18,8 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.testcontainers.containers.PostgreSQLContainer
 import java.sql.DriverManager
-import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
-@OptIn(ExperimentalUuidApi::class)
 class EventsRepositoryTest {
     companion object {
         lateinit var eventRepository: EventsRepository
@@ -106,7 +104,6 @@ class EventsRepositoryTest {
         "refToMessageId1"
     )
 
-    @OptIn(ExperimentalUuidApi::class)
     private fun buildTestEvent(requestId: Uuid) = Event(
         Uuid.random(),
         requestId,

--- a/ebms-async/src/test/kotlin/no/nav/emottak/ebms/async/persistence/PayloadRepositoryTest.kt
+++ b/ebms-async/src/test/kotlin/no/nav/emottak/ebms/async/persistence/PayloadRepositoryTest.kt
@@ -11,10 +11,8 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.testcontainers.containers.PostgreSQLContainer
 import java.sql.DriverManager
-import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
-@OptIn(ExperimentalUuidApi::class)
 class PayloadRepositoryTest {
     companion object {
         lateinit var payloadRepository: PayloadRepository

--- a/ebms-async/src/test/kotlin/no/nav/emottak/ebms/async/processing/SignalProcessorTest.kt
+++ b/ebms-async/src/test/kotlin/no/nav/emottak/ebms/async/processing/SignalProcessorTest.kt
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.util.UUID
 import javax.xml.bind.UnmarshalException
-import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
 class SignalProcessorTest {
@@ -23,7 +22,6 @@ class SignalProcessorTest {
     val cpaValidationService = mockk<CPAValidationService>()
     val signalProcessor = SignalProcessor(repository, cpaValidationService)
 
-    @OptIn(ExperimentalUuidApi::class)
     @Test
     fun `Process acknowledgment goes OK`() {
         every {
@@ -74,7 +72,6 @@ class SignalProcessorTest {
 
 val validationResult = ValidationResult()
 
-@OptIn(ExperimentalUuidApi::class)
 val ebmsMessageDetails = EbmsMessageDetails(
     Uuid.random(),
     "123",


### PR DESCRIPTION
1. Utført registrering av hendelser:
```
PAYLOAD_SAVED_INTO_DATABASE
ERROR_WHILE_SAVING_PAYLOAD_INTO_DATABASE
PAYLOAD_READ_FROM_DATABASE
ERROR_WHILE_READING_PAYLOAD_FROM_DATABASE
PAYLOAD_RECEIVED_VIA_HTTP
ERROR_WHILE_RECEIVING_PAYLOAD_VIA_HTTP
MESSAGE_PLACED_IN_QUEUE
ERROR_WHILE_STORING_MESSAGE_IN_QUEUE
MESSAGE_READ_FROM_QUEUE
```
2. Endret navn på en lokal Kafka konfigurasjon klass fra `Kafka` til `KafkaLocal` fordi felles Kafka konfigurasjon klass fra `emottak-utils` heter også `Kafka`.
3. Fjernet `@OptIn` merknader fra klasser.