### PR TITLE
SyncReply element in response ebXML messages made optional

### DIFF
--- a/ebxml-processing-model/src/main/kotlin/no/nav/emottak/message/model/EbmsMessage.kt
+++ b/ebxml-processing-model/src/main/kotlin/no/nav/emottak/message/model/EbmsMessage.kt
@@ -55,27 +55,25 @@ abstract class EbmsMessage {
     }
 }
 
-fun EbmsMessage.createAcknowledgementJaxB(): org.oasis_open.committees.ebxml_msg.schema.msg_header_2_0.Acknowledgment {
-    val acknowledgment = Acknowledgment()
-    acknowledgment.id = "ACK_ID" // Identifier for Acknowledgment elementet, IKKE message ID (ebms spec 2.3.7)
-    acknowledgment.version = "2.0"
-    acknowledgment.isMustUnderstand = true // Alltid
-    acknowledgment.actor = "http://schemas.xmlsoap.org/soap/actor/next"
-    acknowledgment.timestamp = Date.from(this.mottatt)
-    acknowledgment.refToMessageId = this.messageId
-    acknowledgment.from = From().apply {
-        this.partyId.addAll(
-            this@createAcknowledgementJaxB.addressing.from.partyId.map {
-                PartyId().apply {
-                    this.value = it.value
-                    this.type = it.type
+fun EbmsMessage.createAcknowledgementJaxB(): Acknowledgment =
+    Acknowledgment().apply {
+        version = "2.0"
+        isMustUnderstand = true // Alltid
+        actor = "http://schemas.xmlsoap.org/soap/actor/next"
+        timestamp = Date.from(this@createAcknowledgementJaxB.mottatt)
+        refToMessageId = this@createAcknowledgementJaxB.messageId
+        from = From().apply {
+            this.partyId.addAll(
+                this@createAcknowledgementJaxB.addressing.from.partyId.map {
+                    PartyId().apply {
+                        this.value = it.value
+                        this.type = it.type
+                    }
                 }
-            }
-        )
-        this.role = this@createAcknowledgementJaxB.addressing.from.role
+            )
+            this.role = this@createAcknowledgementJaxB.addressing.from.role
+        }
     }
-    return acknowledgment
-}
 
 @OptIn(ExperimentalUuidApi::class)
 fun EbmsMessage.createMessageHeader(newAddressing: Addressing = this.addressing, withAcknowledgmentElement: Boolean = false): Header {

--- a/ebxml-processing-model/src/main/kotlin/no/nav/emottak/message/model/EbmsMessage.kt
+++ b/ebxml-processing-model/src/main/kotlin/no/nav/emottak/message/model/EbmsMessage.kt
@@ -76,7 +76,11 @@ fun EbmsMessage.createAcknowledgementJaxB(): Acknowledgment =
     }
 
 @OptIn(ExperimentalUuidApi::class)
-fun EbmsMessage.createMessageHeader(newAddressing: Addressing = this.addressing, withAcknowledgmentElement: Boolean = false): Header {
+fun EbmsMessage.createMessageHeader(
+    newAddressing: Addressing = this.addressing,
+    withAcknowledgmentElement: Boolean = false,
+    withSyncReplyElement: Boolean = false
+): Header {
     val messageData = MessageData().apply {
         this.messageId = Uuid.random().toString()
         this.refToMessageId = this@createMessageHeader.refToMessageId
@@ -104,12 +108,6 @@ fun EbmsMessage.createMessageHeader(newAddressing: Addressing = this.addressing,
             }.toList()
         )
     }
-    // TODO SyncReply should not be present for SMTP messages
-    val syncReply = SyncReply().apply {
-        this.actor = "http://schemas.xmlsoap.org/soap/actor/next"
-        this.isMustUnderstand = true
-        this.version = "2.0"
-    }
     val messageHeader = MessageHeader().apply {
         this.from = from
         this.to = to
@@ -126,11 +124,16 @@ fun EbmsMessage.createMessageHeader(newAddressing: Addressing = this.addressing,
     }
 
     return Header().apply {
-        this.any.addAll(
-            listOf(messageHeader, syncReply)
-        )
+        this.any.add(messageHeader)
+        if (withSyncReplyElement) this.any.add(createSyncReplyElement())
         if (withAcknowledgmentElement) this.any.add(createAcknowledgementJaxB())
     }
+}
+
+private fun createSyncReplyElement() = SyncReply().apply {
+    this.actor = "http://schemas.xmlsoap.org/soap/actor/next"
+    this.isMustUnderstand = true
+    this.version = "2.0"
 }
 
 @OptIn(ExperimentalUuidApi::class)


### PR DESCRIPTION
4.3 in https://www.oasis-open.org/committees/ebxml-msg/documents/ebMS_v2_0.pdf, says SyncReply should be added by senders av request messages. It should not be present for smtp-messages, or response messages where we do not expect a response. 