### PR TITLE
Support for new test certificates

### DIFF
--- a/.nais/ebms-async-dev.yaml
+++ b/.nais/ebms-async-dev.yaml
@@ -71,7 +71,7 @@ spec:
     - name: KEYSTORE_FILE_SIGN_2022
       value: /var/run/secrets/ebms-keystore-signering/signering-key.p12
     - name: KEYSTORE_FILE_SIGN_2025
-      value: /var/run/secrets/ebms-keystore-signering-2025/signering-key.p12
+      value: /var/run/secrets/ebms-signing-keystore-2025/nav_signing_test.p12
     - name: EMOTTAK_LOGGING_LEVEL
       value: DEBUG
     - name: MAX_CONNECTION_POOL_SIZE_FOR_USER
@@ -107,4 +107,4 @@ spec:
     - secret: ebms-keystore-signering
       mountPath: /var/run/secrets/ebms-keystore-signering
     - secret: ebms-keystore-sign-2025
-      mountPath: /var/run/secrets/ebms-keystore-signering-2025
+      mountPath: /var/run/secrets/ebms-signing-keystore-2025

--- a/.nais/ebms-async-dev.yaml
+++ b/.nais/ebms-async-dev.yaml
@@ -68,8 +68,10 @@ spec:
       rules:
         - application: smtp-transport
   env:
-    - name: KEYSTORE_FILE
+    - name: KEYSTORE_FILE_SIGN_2022
       value: /var/run/secrets/ebms-keystore-signering/signering-key.p12
+    - name: KEYSTORE_FILE_SIGN_2025
+      value: /var/run/secrets/ebms-keystore-signering-2025/signering-key.p12
     - name: EMOTTAK_LOGGING_LEVEL
       value: DEBUG
     - name: MAX_CONNECTION_POOL_SIZE_FOR_USER
@@ -100,6 +102,9 @@ spec:
       value: http://emottak-event-manager
   envFrom:
     - secret: ebms-payload-secret
+    - secret: ebms-keystore-pwd-2025
   filesFrom:
     - secret: ebms-keystore-signering
       mountPath: /var/run/secrets/ebms-keystore-signering
+    - secret: ebms-keystore-sign-2025
+      mountPath: /var/run/secrets/ebms-keystore-signering-2025

--- a/.nais/ebms-async-dev.yaml
+++ b/.nais/ebms-async-dev.yaml
@@ -71,7 +71,7 @@ spec:
     - name: KEYSTORE_FILE_SIGN_2022
       value: /var/run/secrets/ebms-keystore-signering/signering-key.p12
     - name: KEYSTORE_FILE_SIGN_2025
-      value: /var/run/secrets/ebms-signing-keystore-2025/nav_signing_test.p12
+      value: /var/run/secrets/ebms-keystore-2025/nav_signing_test.p12
     - name: EMOTTAK_LOGGING_LEVEL
       value: DEBUG
     - name: MAX_CONNECTION_POOL_SIZE_FOR_USER
@@ -106,5 +106,5 @@ spec:
   filesFrom:
     - secret: ebms-keystore-signering
       mountPath: /var/run/secrets/ebms-keystore-signering
-    - secret: ebms-keystore-sign-2025
-      mountPath: /var/run/secrets/ebms-signing-keystore-2025
+    - secret: ebms-keystore-2025
+      mountPath: /var/run/secrets/ebms-keystore-2025

--- a/.nais/ebms-payload-dev.yaml
+++ b/.nais/ebms-payload-dev.yaml
@@ -79,9 +79,9 @@ spec:
     - name: KEYSTORE_FILE_SIGN_2022
       value: /var/run/secrets/ebms-signing-keystore/nav_signing_test.p12
     - name: KEYSTORE_FILE_DEKRYPT_2025
-      value: /var/run/secrets/ebms-signing-keystore-2025/nav_encryption_test.p12
+      value: /var/run/secrets/ebms-encryption-keystore-2025/nav_encryption_test.p12
     - name: KEYSTORE_FILE_SIGN_2025
-      value: /var/run/secrets/ebms-encryption-keystore-2025/nav_signing_test.p12
+      value: /var/run/secrets/ebms-signing-keystore-2025/nav_signing_test.p12
     - name: EMOTTAK_LOGGING_LEVEL
       value: DEBUG
     - name: TRUSTSTORE_PATH

--- a/.nais/ebms-payload-dev.yaml
+++ b/.nais/ebms-payload-dev.yaml
@@ -63,16 +63,25 @@ spec:
   webproxy: true
   envFrom:
     - secret: ebms-payload-secret
+    - secret: ebms-keystore-pwd-2025
   filesFrom:
     - secret: ebms-payload-sign-keystore
       mountPath: /var/run/secrets/ebms-signing-keystore
     - secret: ebms-payload-enc-keystore
       mountPath: /var/run/secrets/ebms-encryption-keystore
+    - secret: ebms-keystore-sign-2025
+      mountPath: /var/run/secrets/ebms-signing-keystore-2025
+    - secret: ebms-keystore-enc-2025
+      mountPath: /var/run/secrets/ebms-encryption-keystore-2025
   env:
-    - name: KEYSTORE_FILE_DEKRYPT
+    - name: KEYSTORE_FILE_DEKRYPT_2022
       value: /var/run/secrets/ebms-encryption-keystore/nav_encryption_test.p12
-    - name: KEYSTORE_FILE_SIGN
+    - name: KEYSTORE_FILE_SIGN_2022
       value: /var/run/secrets/ebms-signing-keystore/nav_signing_test.p12
+    - name: KEYSTORE_FILE_DEKRYPT_2025
+      value: /var/run/secrets/ebms-signing-keystore-2025/nav_encryption_test.p12
+    - name: KEYSTORE_FILE_SIGN_2025
+      value: /var/run/secrets/ebms-encryption-keystore-2025/nav_signing_test.p12
     - name: EMOTTAK_LOGGING_LEVEL
       value: DEBUG
     - name: TRUSTSTORE_PATH

--- a/.nais/ebms-payload-dev.yaml
+++ b/.nais/ebms-payload-dev.yaml
@@ -69,19 +69,17 @@ spec:
       mountPath: /var/run/secrets/ebms-signing-keystore
     - secret: ebms-payload-enc-keystore
       mountPath: /var/run/secrets/ebms-encryption-keystore
-    - secret: ebms-keystore-sign-2025
-      mountPath: /var/run/secrets/ebms-signing-keystore-2025
-    - secret: ebms-keystore-enc-2025
-      mountPath: /var/run/secrets/ebms-encryption-keystore-2025
+    - secret: ebms-keystore-2025
+      mountPath: /var/run/secrets/ebms-keystore-2025
   env:
     - name: KEYSTORE_FILE_DEKRYPT_2022
       value: /var/run/secrets/ebms-encryption-keystore/nav_encryption_test.p12
     - name: KEYSTORE_FILE_SIGN_2022
       value: /var/run/secrets/ebms-signing-keystore/nav_signing_test.p12
     - name: KEYSTORE_FILE_DEKRYPT_2025
-      value: /var/run/secrets/ebms-encryption-keystore-2025/nav_encryption_test.p12
+      value: /var/run/secrets/ebms-keystore-2025/nav_encryption_test.p12
     - name: KEYSTORE_FILE_SIGN_2025
-      value: /var/run/secrets/ebms-signing-keystore-2025/nav_signing_test.p12
+      value: /var/run/secrets/ebms-keystore-2025/nav_signing_test.p12
     - name: EMOTTAK_LOGGING_LEVEL
       value: DEBUG
     - name: TRUSTSTORE_PATH

--- a/.nais/ebms-provider-dev.yaml
+++ b/.nais/ebms-provider-dev.yaml
@@ -66,7 +66,7 @@ spec:
     - name: KEYSTORE_FILE_SIGN_2022
       value: /var/run/secrets/ebms-keystore-signering/signering-key.p12
     - name: KEYSTORE_FILE_SIGN_2025
-      value: /var/run/secrets/ebms-keystore-signering-2025/signering-key.p12
+      value: /var/run/secrets/ebms-signing-keystore-2025/nav_signing_test.p12
     - name: EMOTTAK_LOGGING_LEVEL
       value: DEBUG
     - name: CPA_REPO_URL
@@ -84,4 +84,4 @@ spec:
     - secret: ebms-keystore-signering
       mountPath: /var/run/secrets/ebms-keystore-signering
     - secret: ebms-keystore-sign-2025
-      mountPath: /var/run/secrets/ebms-keystore-signering-2025
+      mountPath: /var/run/secrets/ebms-signing-keystore-2025

--- a/.nais/ebms-provider-dev.yaml
+++ b/.nais/ebms-provider-dev.yaml
@@ -63,8 +63,10 @@ spec:
         - application: ebms-payload
         - application: ebms-send-in
   env:
-    - name: KEYSTORE_FILE
+    - name: KEYSTORE_FILE_SIGN_2022
       value: /var/run/secrets/ebms-keystore-signering/signering-key.p12
+    - name: KEYSTORE_FILE_SIGN_2025
+      value: /var/run/secrets/ebms-keystore-signering-2025/signering-key.p12
     - name: EMOTTAK_LOGGING_LEVEL
       value: DEBUG
     - name: CPA_REPO_URL
@@ -77,6 +79,9 @@ spec:
       value: http://smtp-transport
   envFrom:
     - secret: ebms-payload-secret
+    - secret: ebms-keystore-pwd-2025
   filesFrom:
     - secret: ebms-keystore-signering
       mountPath: /var/run/secrets/ebms-keystore-signering
+    - secret: ebms-keystore-sign-2025
+      mountPath: /var/run/secrets/ebms-keystore-signering-2025

--- a/.nais/ebms-provider-dev.yaml
+++ b/.nais/ebms-provider-dev.yaml
@@ -66,7 +66,7 @@ spec:
     - name: KEYSTORE_FILE_SIGN_2022
       value: /var/run/secrets/ebms-keystore-signering/signering-key.p12
     - name: KEYSTORE_FILE_SIGN_2025
-      value: /var/run/secrets/ebms-signing-keystore-2025/nav_signing_test.p12
+      value: /var/run/secrets/ebms-keystore-2025/nav_signing_test.p12
     - name: EMOTTAK_LOGGING_LEVEL
       value: DEBUG
     - name: CPA_REPO_URL
@@ -83,5 +83,5 @@ spec:
   filesFrom:
     - secret: ebms-keystore-signering
       mountPath: /var/run/secrets/ebms-keystore-signering
-    - secret: ebms-keystore-sign-2025
-      mountPath: /var/run/secrets/ebms-signing-keystore-2025
+    - secret: ebms-keystore-2025
+      mountPath: /var/run/secrets/ebms-keystore-2025

--- a/ebms-payload/src/main/kotlin/no/nav/emottak/payload/crypto/Dekryptering.kt
+++ b/ebms-payload/src/main/kotlin/no/nav/emottak/payload/crypto/Dekryptering.kt
@@ -24,8 +24,13 @@ private fun dekrypteringConfig() =
             // Fixme burde egentlig hente fra dev vault context for å matche prod oppførsel
             listOf(
                 FileKeyStoreConfig(
-                    keyStoreFilePath = getEnvVar("KEYSTORE_FILE_DEKRYPT"),
+                    keyStoreFilePath = getEnvVar("KEYSTORE_FILE_DEKRYPT_2022"),
                     keyStorePass = getEnvVar("KEYSTORE_PWD").toCharArray(),
+                    keyStoreType = getEnvVar("KEYSTORE_TYPE", "PKCS12")
+                ),
+                FileKeyStoreConfig(
+                    keyStoreFilePath = getEnvVar("KEYSTORE_FILE_DEKRYPT_2025"),
+                    keyStorePass = getEnvVar("KEYSTORE_PWD_2025").toCharArray(),
                     keyStoreType = getEnvVar("KEYSTORE_TYPE", "PKCS12")
                 )
             )

--- a/ebms-payload/src/main/kotlin/no/nav/emottak/payload/crypto/PayloadSignering.kt
+++ b/ebms-payload/src/main/kotlin/no/nav/emottak/payload/crypto/PayloadSignering.kt
@@ -26,8 +26,13 @@ fun payloadSigneringConfig() =
             // Fixme burde egentlig hente fra dev vault context for å matche prod oppførsel
             listOf(
                 FileKeyStoreConfig(
-                    keyStoreFilePath = getEnvVar("KEYSTORE_FILE_SIGN"),
+                    keyStoreFilePath = getEnvVar("KEYSTORE_FILE_SIGN_2022"),
                     keyStorePass = getEnvVar("KEYSTORE_PWD").toCharArray(),
+                    keyStoreType = getEnvVar("KEYSTORE_TYPE", "PKCS12")
+                ),
+                FileKeyStoreConfig(
+                    keyStoreFilePath = getEnvVar("KEYSTORE_FILE_SIGN_2025"),
+                    keyStorePass = getEnvVar("KEYSTORE_PWD_2025").toCharArray(),
                     keyStoreType = getEnvVar("KEYSTORE_TYPE", "PKCS12")
                 )
             )

--- a/ebms-provider/src/main/kotlin/no/nav/emottak/ebms/xml/EbMSSigning.kt
+++ b/ebms-provider/src/main/kotlin/no/nav/emottak/ebms/xml/EbMSSigning.kt
@@ -30,8 +30,13 @@ fun signeringConfig() =
             // Fixme burde egentlig hente fra dev vault context for å matche prod oppførsel
             listOf(
                 FileKeyStoreConfig(
-                    keyStoreFilePath = getEnvVar("KEYSTORE_FILE"),
+                    keyStoreFilePath = getEnvVar("KEYSTORE_FILE_SIGN_2022"),
                     keyStorePass = getEnvVar("KEYSTORE_PWD").toCharArray(),
+                    keyStoreType = getEnvVar("KEYSTORE_TYPE", "PKCS12")
+                ),
+                FileKeyStoreConfig(
+                    keyStoreFilePath = getEnvVar("KEYSTORE_FILE_SIGN_2025"),
+                    keyStorePass = getEnvVar("KEYSTORE_PWD_2025").toCharArray(),
                     keyStoreType = getEnvVar("KEYSTORE_TYPE", "PKCS12")
                 )
             )


### PR DESCRIPTION
Rydding og fjerning av 2022 sertifikatene kommer i en senere PR, etter de har utløpt. 

Nøkler og passord ligger som kubernetes secrets i namespacet vårt i dev-fss.