### PR TITLE
Toggle for aktivering av cpApi og refaktorering

### DIFF
--- a/.nais/cpa-repo-dev.yaml
+++ b/.nais/cpa-repo-dev.yaml
@@ -109,10 +109,10 @@ spec:
       value: /secrets/oracle/creds
     - name: ORACLE_CONFIG_SECRET_PATH
       value: /secrets/oracle/config
-    - name: ADRESSE_REGISTER_URL
-      value: https://cpapi.test.grunndata.nhn.no/api/v1/communicationparty
-    - name: ADRESSE_REGISTER_CERTIFICATE_URL
-      value: https://cpapi.test.grunndata.nhn.no/api/v1/certificate
+    - name: CPAPI_BASE_URL
+      value: https://cpapi.test.grunndata.nhn.no
+    - name: CPAPI_ACTIVE
+      value: "true"
     - name: NHN_KEYPAIR_PATH
       value: "/var/run/secrets/emottak-ar-klient-secret/key"
     - name: NHN_TOKEN_ENDPOINT

--- a/.nais/cpa-repo-prod.yaml
+++ b/.nais/cpa-repo-prod.yaml
@@ -97,10 +97,10 @@ spec:
       value: /secrets/oracle/creds
     - name: ORACLE_CONFIG_SECRET_PATH
       value: /secrets/oracle/config
-    - name: ADRESSE_REGISTER_URL
-      value: https://cpapi.grunndata.nhn.no/api/v1/communicationparty
-    - name: ADRESSE_REGISTER_CERTIFICATE_URL
-      value: https://cpapi.grunndata.nhn.no/api/v1/certificate
+    - name: CPAPI_BASE_URL
+      value: https://cpapi.grunndata.nhn.no
+    - name: CPAPI_ACTIVE
+      value: "false"
     - name: NHN_KEYPAIR_PATH
       value: "/var/run/secrets/emottak-ar-klient-secret/key"
     - name: NHN_TOKEN_ENDPOINT

--- a/cpa-repo/src/main/kotlin/no/nav/emottak/cpa/App.kt
+++ b/cpa-repo/src/main/kotlin/no/nav/emottak/cpa/App.kt
@@ -29,8 +29,8 @@ import no.nav.emottak.cpa.persistence.gammel.PartnerRepository
 import no.nav.emottak.cpa.persistence.oracleConfig
 import no.nav.emottak.cpa.util.EventRegistrationService
 import no.nav.emottak.cpa.util.EventRegistrationServiceImpl
+import no.nav.emottak.cpa.validation.AdresseregisterValidator
 import no.nav.emottak.util.jsonLenient
-import no.nav.emottak.utils.environment.isProdEnv
 import no.nav.emottak.utils.kafka.client.EventPublisherClient
 import no.nav.emottak.utils.kafka.service.EventLoggingService
 import no.nav.security.token.support.v3.tokenValidationSupport
@@ -39,10 +39,17 @@ import org.slf4j.LoggerFactory
 
 internal val log = LoggerFactory.getLogger("no.nav.emottak.cpa.App")
 fun main() {
-    val kafkaPublisherClient = EventPublisherClient(config().kafka)
-    val eventLoggingService = EventLoggingService(config().eventLogging, kafkaPublisherClient)
+    val kafkaPublisherClient = EventPublisherClient(config.kafka)
+    val eventLoggingService = EventLoggingService(config.eventLogging, kafkaPublisherClient)
     val eventRegistrationService = EventRegistrationServiceImpl(eventLoggingService)
-    val adresseregisterClient = if (!isProdEnv()) nhnArHttpClient() else null
+    val adresseregisterValidator = if (config.nhn.cpApiActive) {
+        AdresseregisterValidator(
+            httpClient = nhnArHttpClient(config.nhnOAuth, config.nhn),
+            nhnConfig = config.nhn
+        )
+    } else {
+        null
+    }
 
     embeddedServer(
         Netty,
@@ -52,7 +59,7 @@ fun main() {
             cpaMigrationConfig.value,
             oracleConfig.value,
             eventRegistrationService,
-            adresseregisterClient
+            adresseregisterValidator
         )
     ).start(wait = true)
 }
@@ -62,7 +69,7 @@ fun cpaApplicationModule(
     cpaMigrationConfig: HikariConfig,
     emottakDbConfig: HikariConfig? = null,
     eventRegistrationService: EventRegistrationService,
-    adresseregisterClient: HttpClient?
+    adresseregisterValidator: AdresseregisterValidator?
 ): Application.() -> Unit {
     return {
         val database = Database(cpaDbConfig)
@@ -87,7 +94,7 @@ fun cpaApplicationModule(
         routing {
             if (oracleDb != null) {
                 partnerId(PartnerRepository(oracleDb), cpaRepository)
-                validateCpa(cpaRepository, PartnerRepository(oracleDb), eventRegistrationService, adresseregisterClient)
+                validateCpa(cpaRepository, PartnerRepository(oracleDb), eventRegistrationService, adresseregisterValidator)
             }
             getCPA(cpaRepository)
             getCpaView(cpaRepository)
@@ -96,13 +103,13 @@ fun cpaApplicationModule(
             getTimeStampsLatestDeprecated()
             getTimeStampsLatest(cpaRepository)
             getTimeStampsLastUsed(cpaRepository)
-            getCertificate(cpaRepository)
-            signingCertificate(cpaRepository, adresseregisterClient)
-            getMessagingCharacteristics(cpaRepository, adresseregisterClient)
-            if (adresseregisterClient != null) {
-                getAdresseregisterData(adresseregisterClient)
-                getARSignCertificate(adresseregisterClient)
-                getAREncryptCertificate(adresseregisterClient)
+            getEncryptionCertificate(cpaRepository)
+            getSigningCertificate(cpaRepository, adresseregisterValidator)
+            getMessagingCharacteristics(cpaRepository)
+            if (adresseregisterValidator != null) {
+                getAdresseregisterData(adresseregisterValidator)
+                getARSignCertificate(adresseregisterValidator)
+                getAREncryptCertificate(adresseregisterValidator)
             }
             registerHealthEndpoints(appMicrometerRegistry, cpaRepository)
 

--- a/cpa-repo/src/main/kotlin/no/nav/emottak/cpa/Routes.kt
+++ b/cpa-repo/src/main/kotlin/no/nav/emottak/cpa/Routes.kt
@@ -1,10 +1,5 @@
 package no.nav.emottak.cpa
 
-import io.ktor.client.HttpClient
-import io.ktor.client.call.body
-import io.ktor.client.request.get
-import io.ktor.client.statement.HttpResponse
-import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.auth.authentication
@@ -25,15 +20,13 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import no.nav.emottak.cpa.auth.AZURE_AD_AUTH
-import no.nav.emottak.cpa.configuration.config
 import no.nav.emottak.cpa.feil.CpaValidationException
 import no.nav.emottak.cpa.feil.MultiplePartnerException
 import no.nav.emottak.cpa.feil.PartnerNotFoundException
-import no.nav.emottak.cpa.model.Certificate
-import no.nav.emottak.cpa.model.CommunicationParty
 import no.nav.emottak.cpa.persistence.CPARepository
 import no.nav.emottak.cpa.persistence.gammel.PartnerRepository
 import no.nav.emottak.cpa.util.EventRegistrationService
+import no.nav.emottak.cpa.validation.AdresseregisterValidator
 import no.nav.emottak.cpa.validation.MessageDirection
 import no.nav.emottak.cpa.validation.log
 import no.nav.emottak.cpa.validation.partyInfoHasRoleServiceActionCombo
@@ -238,7 +231,7 @@ fun Route.validateCpa(
     cpaRepository: CPARepository,
     partnerRepository: PartnerRepository,
     eventRegistrationService: EventRegistrationService,
-    httpClient: HttpClient?
+    adresseregisterValidator: AdresseregisterValidator?
 ) = post("/cpa/validate/{$REQUEST_ID}") {
     val validateRequest = call.receive(ValidationRequest::class)
 
@@ -247,44 +240,52 @@ fun Route.validateCpa(
         log.info(validateRequest.marker(), "Validerer ebms mot CPA")
         val (cpa, lastUsed) = cpaRepository.findCpaAndLastUsed(validateRequest.cpaId)
         if (cpa == null) {
-            val PartnerHerId = validateRequest.addressing.from.partyId.firstOrNull()?.value
-            val navHerId = validateRequest.addressing.to.partyId.firstOrNull()?.value
-            log.warn("Cpa finnes ikke for Partner $PartnerHerId. Forsøker å hente informasjon fra adresseregisteret.")
-            try {
-                val fromEdi = httpClient?.fetchAREdiAddress(PartnerHerId)
-                val toEdi = httpClient?.fetchAREdiAddress(navHerId)
-                val signalEmails = listOf(EmailAddress(fromEdi ?: "", EndpointTypeType.REQUEST))
-                val receiverEmails = listOf(EmailAddress(toEdi ?: "", EndpointTypeType.REQUEST))
-                val arSignCertificate = httpClient?.fetchARSignCertificate("$PartnerHerId")
-                val encryptionCertificate = httpClient?.fetchAREncryptCertificate("$navHerId")
-                val validSignatureDetails = SignatureDetails(
-                    certificate = decodeBase64(arSignCertificate!!.certificateValue.toByteArray()),
-                    signatureAlgorithm = XMLSignature.ALGO_ID_SIGNATURE_RSA_SHA256,
-                    hashFunction = MessageDigestAlgorithm.ALGO_ID_DIGEST_SHA256
-                )
-                runCatching {
-                    createX509Certificate(validSignatureDetails.certificate).validate()
-                }.onFailure {
-                    log.warn(validateRequest.marker(), "Signatursjekk feilet", it)
-                }
-                val validate = ValidationResult(
-                    EbmsProcessing(),
-                    PayloadProcessing(
-                        validSignatureDetails,
-                        encryptionCertificate!!.certificateValue.toByteArray(),
-                        cpaRepository.getProcessConfig(
-                            validateRequest.addressing.from.role,
-                            validateRequest.addressing.service,
-                            validateRequest.addressing.action
+            if (adresseregisterValidator != null && adresseregisterValidator.cpapiActive) {
+                val fromHerId = validateRequest.addressing.from.partyId.firstOrNull()?.value ?: throw BadRequestException("Mangler avsender HER")
+                val toHerId = validateRequest.addressing.to.partyId.firstOrNull()?.value ?: throw BadRequestException("Mangler mottaker HER")
+                log.warn("Cpa finnes ikke for Partner $fromHerId. Forsøker å hente informasjon fra adresseregisteret.")
+                try {
+                    val toEdiAddress = adresseregisterValidator.getEdiAddress(toHerId)
+                    val signalEmails = listOf(EmailAddress(toEdiAddress ?: "", EndpointTypeType.ALL_PURPOSE))
+                    val receiverEmails = listOf(EmailAddress(toEdiAddress ?: "", EndpointTypeType.ALL_PURPOSE))
+                    val signingCertificate = decodeBase64(
+                        adresseregisterValidator.getSigningCertificate(fromHerId).certificateValue.toByteArray()
+                    )
+                    val encryptionCertificate = decodeBase64(
+                        adresseregisterValidator.getEncryptionCertificate(toHerId).certificateValue.toByteArray()
+                    )
+                    val validSignatureDetails = SignatureDetails(
+                        certificate = signingCertificate,
+                        signatureAlgorithm = XMLSignature.ALGO_ID_SIGNATURE_RSA_SHA256,
+                        hashFunction = MessageDigestAlgorithm.ALGO_ID_DIGEST_SHA256
+                    )
+                    runCatching {
+                        createX509Certificate(validSignatureDetails.certificate).validate()
+                    }.onFailure {
+                        log.warn(validateRequest.marker(), "Signatursjekk feilet", it)
+                    }
+                    call.respond(
+                        ValidationResult(
+                            EbmsProcessing(),
+                            PayloadProcessing(
+                                validSignatureDetails,
+                                encryptionCertificate,
+                                cpaRepository.getProcessConfig(
+                                    validateRequest.addressing.from.role,
+                                    validateRequest.addressing.service,
+                                    validateRequest.addressing.action
+                                )
+                            ),
+                            signalEmails,
+                            receiverEmails
                         )
-                    ),
-                    signalEmails,
-                    receiverEmails
-                )
-                call.respond(validate)
-            } catch (ex: Exception) {
-                log.error("Error while fetching arSignCertificate ", ex)
-                call.respondText(ex.localizedMessage, ContentType.Text.Plain, HttpStatusCode.InternalServerError)
+                    )
+                } catch (ex: Exception) {
+                    log.error("Error while fetching arSignCertificate ", ex)
+                    call.respondText(ex.localizedMessage, ContentType.Text.Plain, HttpStatusCode.InternalServerError)
+                }
+            } else {
+                throw NotFoundException("Fant ikke CPA")
             }
         } else {
             if (!lastUsed.isToday() && !cpaRepository.updateCpaLastUsed(validateRequest.cpaId)) {
@@ -390,7 +391,7 @@ fun Route.validateCpa(
 private fun ValidationRequest.isSignalMessage(): Boolean = this.addressing.service == EBMS_SERVICE_URI &&
     (this.addressing.action == MESSAGE_ERROR_ACTION || this.addressing.action == ACKNOWLEDGMENT_ACTION)
 
-fun Route.getCertificate(cpaRepository: CPARepository) =
+fun Route.getEncryptionCertificate(cpaRepository: CPARepository) =
     get("/cpa/{$CPA_ID}/party/{$PARTY_TYPE}/{$PARTY_ID}/encryption/certificate") {
         val cpaId = call.parameters[CPA_ID] ?: throw BadRequestException("Mangler $CPA_ID")
         val partyType = call.parameters[PARTY_TYPE] ?: throw BadRequestException("Mangler $PARTY_TYPE")
@@ -400,28 +401,35 @@ fun Route.getCertificate(cpaRepository: CPARepository) =
         call.respond(partyInfo.getCertificateForEncryption())
     }
 
-fun Route.signingCertificate(cpaRepository: CPARepository, httpClient: HttpClient?) = post("/signing/certificate") {
+fun Route.getSigningCertificate(cpaRepository: CPARepository, adresseregisterValidator: AdresseregisterValidator?) = post("/signing/certificate") {
     val signatureDetailsRequest = call.receive(SignatureDetailsRequest::class)
     val cpa = cpaRepository.findCpa(signatureDetailsRequest.cpaId)
 
     if (cpa == null) {
-        val herid = signatureDetailsRequest.partyId
-        try {
-            val arSignCertificate = httpClient?.fetchARSignCertificate(herid)
-            val validSignatureDetails = SignatureDetails(
-                certificate = decodeBase64(arSignCertificate!!.certificateValue.toByteArray()),
-                signatureAlgorithm = XMLSignature.ALGO_ID_SIGNATURE_RSA_SHA256,
-                hashFunction = MessageDigestAlgorithm.ALGO_ID_DIGEST_SHA256
-            )
-            runCatching {
-                createX509Certificate(validSignatureDetails.certificate).validate()
-            }.onFailure {
-                log.warn(signatureDetailsRequest.marker(), "Signatursjekk feilet", it)
+        if (adresseregisterValidator != null && adresseregisterValidator.cpapiActive) {
+            val herid = signatureDetailsRequest.partyId
+            try {
+                val signingCertificate = decodeBase64(
+                    adresseregisterValidator.getSigningCertificate(herid).certificateValue.toByteArray()
+                )
+                runCatching {
+                    createX509Certificate(signingCertificate).validate()
+                }.onFailure {
+                    log.warn(signatureDetailsRequest.marker(), "Signatursjekk feilet", it)
+                }
+                call.respond(
+                    SignatureDetails(
+                        certificate = signingCertificate,
+                        signatureAlgorithm = XMLSignature.ALGO_ID_SIGNATURE_RSA_SHA256,
+                        hashFunction = MessageDigestAlgorithm.ALGO_ID_DIGEST_SHA256
+                    )
+                )
+            } catch (ex: Exception) {
+                log.error("Error while fetching arSignCertificate <$herid>", ex)
+                call.respondText(ex.localizedMessage, ContentType.Text.Plain, HttpStatusCode.InternalServerError)
             }
-            call.respond(arSignCertificate as Any)
-        } catch (ex: Exception) {
-            log.error("Error while fetching arSignCertificate <$herid>", ex)
-            call.respondText(ex.localizedMessage, ContentType.Text.Plain, HttpStatusCode.InternalServerError)
+        } else {
+            throw NotFoundException("Ingen CPA med ID ${signatureDetailsRequest.cpaId} funnet")
         }
     } else {
         try {
@@ -446,148 +454,65 @@ fun Route.signingCertificate(cpaRepository: CPARepository, httpClient: HttpClien
     }
 }
 
-fun Route.getMessagingCharacteristics(cpaRepository: CPARepository, httpClient: HttpClient?) =
+fun Route.getMessagingCharacteristics(cpaRepository: CPARepository) =
     post("/cpa/messagingCharacteristics") {
         val request = call.receive(MessagingCharacteristicsRequest::class)
-        val cpa = cpaRepository.findCpa(request.cpaId)
-        if (cpa == null) {
-            val herid = request.partyIds.firstOrNull()?.value.toString()
-            log.info("Partner's information from AR on her id $herid")
-            try {
-                val response = httpClient?.fetchCommunicationParty(herid)
-                call.respond(response as Any)
-            } catch (ex: Exception) {
-                log.error("Error while fetching communication party <$herid>", ex)
-                call.respondText(ex.localizedMessage, ContentType.Text.Plain, HttpStatusCode.InternalServerError)
-            }
-        } else {
-            val fromParty = cpa.getPartyInfoByTypeAndID(request.partyIds)
-            val deliveryChannel = fromParty.getSendDeliveryChannel(request.role, request.service, request.action)
-            val response = MessagingCharacteristicsResponse(
-                requestId = request.requestId,
-                ackRequested = deliveryChannel.messagingCharacteristics.ackRequested,
-                ackSignatureRequested = deliveryChannel.messagingCharacteristics.ackSignatureRequested,
-                duplicateElimination = deliveryChannel.messagingCharacteristics.duplicateElimination
-            )
 
-            call.respond(response)
-        }
+        val cpa = cpaRepository.findCpa(request.cpaId) ?: throw NotFoundException("CPA not found for ID ${request.cpaId}")
+        val fromParty = cpa.getPartyInfoByTypeAndID(request.partyIds)
+        val deliveryChannel = fromParty.getSendDeliveryChannel(request.role, request.service, request.action)
+
+        val response = MessagingCharacteristicsResponse(
+            requestId = request.requestId,
+            ackRequested = deliveryChannel.messagingCharacteristics.ackRequested,
+            ackSignatureRequested = deliveryChannel.messagingCharacteristics.ackSignatureRequested,
+            duplicateElimination = deliveryChannel.messagingCharacteristics.duplicateElimination
+        )
+
+        call.respond(response)
     }
 
-fun Route.getAdresseregisterData(httpClient: HttpClient) =
+fun Route.getAdresseregisterData(adresseregisterValidator: AdresseregisterValidator) =
     get("/cpa/adresseregister/her/{$HER_ID}") {
         val herId = call.parameters[HER_ID] ?: throw BadRequestException("Mangler $HER_ID")
         try {
-            val communicationParty = httpClient.fetchCommunicationParty(herId)
-            call.respond(HttpStatusCode.OK, communicationParty)
+            call.respond(
+                status = HttpStatusCode.OK,
+                message = adresseregisterValidator.getCommunicationParty(herId)
+            )
         } catch (ex: Exception) {
             log.error("Error while fetching communication party <$herId>", ex)
             call.respondText(ex.localizedMessage, ContentType.Text.Plain, HttpStatusCode.InternalServerError)
         }
     }
 
-fun Route.getARSignCertificate(httpClient: HttpClient) =
+fun Route.getARSignCertificate(adresseregisterValidator: AdresseregisterValidator) =
     get("/cpa/adresseregister/her/{$HER_ID}/signing") {
         val herId = call.parameters[HER_ID] ?: throw BadRequestException("Mangler $HER_ID")
         try {
-            val certificate = httpClient.fetchARSignCertificate(herId)
-            call.respond(HttpStatusCode.OK, certificate)
+            call.respond(
+                status = HttpStatusCode.OK,
+                message = adresseregisterValidator.getSigningCertificate(herId)
+            )
         } catch (ex: Exception) {
             log.error("Error while fetching signing certificate <$herId>", ex)
             call.respondText(ex.localizedMessage, ContentType.Text.Plain, HttpStatusCode.InternalServerError)
         }
     }
 
-fun Route.getAREncryptCertificate(httpClient: HttpClient) =
+fun Route.getAREncryptCertificate(adresseregisterValidator: AdresseregisterValidator) =
     get("/cpa/adresseregister/her/{$HER_ID}/encryption") {
         val herId = call.parameters[HER_ID] ?: throw BadRequestException("Mangler $HER_ID")
         try {
-            val certificate = httpClient.fetchAREncryptCertificate(herId)
-            call.respond(certificate)
+            call.respond(
+                status = HttpStatusCode.OK,
+                message = adresseregisterValidator.getEncryptionCertificate(herId)
+            )
         } catch (ex: Exception) {
             log.error("Error while fetching encryption certificate <$herId>", ex)
-            call.respondText(
-                ex.localizedMessage,
-                ContentType.Text.Plain,
-                HttpStatusCode.InternalServerError
-            )
+            call.respondText(ex.localizedMessage, ContentType.Text.Plain, HttpStatusCode.InternalServerError)
         }
     }
-
-suspend fun HttpClient.fetchAREdiAddress(herId: String? = null): String? {
-    val baseUrl = config().nhn.adresseregisterApiBaseUrl
-    return try {
-        val response: HttpResponse = this.get("$baseUrl/$herId")
-        if (response.status == HttpStatusCode.OK) {
-            log.info("Data mottatt: ${response.bodyAsText()}")
-        } else {
-            log.warn("Feil ved oppslag: ${response.status}")
-        }
-
-        val communicationParty = response.body<CommunicationParty>()
-        communicationParty.ediAddress
-    } catch (e: Exception) {
-        log.error("Kunne ikke koble til $baseUrl: ${e.localizedMessage}", e)
-        e.localizedMessage
-        throw e
-    }
-}
-
-suspend fun HttpClient.fetchCommunicationParty(herId: String? = null): CommunicationParty {
-    val baseUrl = config().nhn.adresseregisterApiBaseUrl // "https://cpa-repo-fss.intern.dev.nav.no/cpa/adresseregister/her"
-    return try {
-        val response: HttpResponse = this.get("$baseUrl/$herId")
-        if (response.status == HttpStatusCode.OK) {
-            log.info("Data mottatt: ${response.bodyAsText()}")
-        } else {
-            log.warn("Feil ved oppslag: ${response.status}")
-        }
-
-        val communicationParty = response.body<CommunicationParty>()
-        communicationParty
-    } catch (e: Exception) {
-        log.error("Kunne ikke koble til $baseUrl: ${e.localizedMessage}", e)
-        e.localizedMessage
-        throw e
-    }
-}
-
-suspend fun HttpClient.fetchARSignCertificate(herId: String): Certificate {
-    val baseUrl = config().nhn.adresseregisterApiCertificateBaseUrl
-    return try {
-        val response: HttpResponse = this.get("$baseUrl/$herId/signing")
-        if (response.status == HttpStatusCode.OK) {
-            log.info("Data mottatt: ${response.bodyAsText()}")
-        } else {
-            log.warn("Connect to $$baseUrl: herId: $herId  ${response.status} ")
-        }
-
-        response.body<Certificate>()
-    } catch (e: Exception) {
-        log.error("fetchARSignCertificate: Kunne ikke koble til $baseUrl: $herId ${e.localizedMessage}", e)
-        e.localizedMessage
-        throw e
-    }
-}
-
-suspend fun HttpClient.fetchAREncryptCertificate(herId: String): Certificate {
-    val baseUrl = config().nhn.adresseregisterApiCertificateBaseUrl
-
-    return try {
-        val response: HttpResponse = this.get("$baseUrl/$herId/encryption")
-        if (response.status == HttpStatusCode.OK) {
-            log.info("Data mottatt: ${response.bodyAsText()}")
-        } else {
-            log.warn("Feil ved oppslag: ${response.status}")
-        }
-
-        response.body<Certificate>()
-    } catch (e: Exception) {
-        log.error("Kunne ikke koble til $baseUrl: ${e.localizedMessage}", e)
-        e.localizedMessage
-        throw e
-    }
-}
 
 fun Routing.registerHealthEndpoints(
     collectorRegistry: PrometheusMeterRegistry,

--- a/cpa-repo/src/main/kotlin/no/nav/emottak/cpa/configuration/Config.kt
+++ b/cpa-repo/src/main/kotlin/no/nav/emottak/cpa/configuration/Config.kt
@@ -40,8 +40,10 @@ data class NhnOAuth(
 }
 
 data class Nhn(
-    val adresseregisterApiBaseUrl: URI,
-    val adresseregisterApiCertificateBaseUrl: URI,
+    val cpApiBaseUrl: URI,
+    val cpApiCommunicationPartyUrl: URI,
+    val cpApiCertificateUrl: URI,
+    val cpApiActive: Boolean,
     val keyPairPath: KeyPairPath
 ) {
     @JvmInline

--- a/cpa-repo/src/main/kotlin/no/nav/emottak/cpa/configuration/Configurator.kt
+++ b/cpa-repo/src/main/kotlin/no/nav/emottak/cpa/configuration/Configurator.kt
@@ -4,6 +4,10 @@ import com.sksamuel.hoplite.ConfigLoader
 import com.sksamuel.hoplite.addEnvironmentSource
 import com.sksamuel.hoplite.addResourceSource
 
+val config by lazy {
+    config()
+}
+
 fun config() = ConfigLoader.builder()
     .addEnvironmentSource()
     .addResourceSource("/application-personal.conf", optional = true)

--- a/cpa-repo/src/main/kotlin/no/nav/emottak/cpa/nhn/adresseregisteret/DpopJwtProvider.kt
+++ b/cpa-repo/src/main/kotlin/no/nav/emottak/cpa/nhn/adresseregisteret/DpopJwtProvider.kt
@@ -18,7 +18,8 @@ import io.ktor.http.HttpMethod.Companion.Post
 import net.minidev.json.JSONObject
 import net.minidev.json.parser.JSONParser
 import net.minidev.json.parser.JSONParser.MODE_PERMISSIVE
-import no.nav.emottak.cpa.configuration.Config
+import no.nav.emottak.cpa.configuration.Nhn
+import no.nav.emottak.cpa.configuration.NhnOAuth
 import java.io.File
 import java.net.URI
 import java.security.MessageDigest.getInstance
@@ -32,11 +33,12 @@ private const val HTU_CLAIM_NAME = "htu"
 private const val ATH_CLAIM_NAME = "ath"
 
 class DpopJwtProvider(
-    private val config: Config
+    private val nhnOAuth: NhnOAuth,
+    private val nhn: Nhn
 ) {
     fun dpopProofWithoutNonce(): String =
         dpopProof(
-            config.nhnOAuth.tokenEndpoint,
+            nhnOAuth.tokenEndpoint,
             Post,
             null,
             null
@@ -44,7 +46,7 @@ class DpopJwtProvider(
 
     fun dpopProofWithNonce(nonce: Nonce): String =
         dpopProof(
-            config.nhnOAuth.tokenEndpoint,
+            nhnOAuth.tokenEndpoint,
             Post,
             nonce,
             null
@@ -69,16 +71,16 @@ class DpopJwtProvider(
                 mapOf(
                     "typ" to "client-authentication+jwt",
                     "alg" to "RS256",
-                    "kid" to config.nhnOAuth.keyId.value
+                    "kid" to nhnOAuth.keyId.value
                 )
             )
-            .withIssuer(config.nhnOAuth.clientId.value)
-            .withSubject(config.nhnOAuth.clientId.value)
-            .withAudience(config.nhnOAuth.audience.value)
+            .withIssuer(nhnOAuth.clientId.value)
+            .withSubject(nhnOAuth.clientId.value)
+            .withAudience(nhnOAuth.audience.value)
             .withJWTId(Uuid.random().toString())
             .withIssuedAt(from(now))
             .withExpiresAt(from(now.plusSeconds(60)))
-            .sign(Algorithm.RSA256(parseKeyPair(config.nhn.keyPairPath.value).toRSAPrivateKey()))
+            .sign(Algorithm.RSA256(parseKeyPair(nhn.keyPairPath.value).toRSAPrivateKey()))
     }
 
     private fun dpopProof(
@@ -93,7 +95,7 @@ class DpopJwtProvider(
         .apply {
             sign(
                 RSASSASigner(
-                    parseKeyPair(config.nhn.keyPairPath.value)
+                    parseKeyPair(nhn.keyPairPath.value)
                         .toRSAPrivateKey()
                 )
             )
@@ -125,7 +127,7 @@ class DpopJwtProvider(
     internal fun rsaKey(): RSAKey =
         RSAKey
             .Builder(
-                parseKeyPair(config.nhn.keyPairPath.value)
+                parseKeyPair(nhn.keyPairPath.value)
                     .toRSAPublicKey()
             )
             .algorithm(RS256)

--- a/cpa-repo/src/main/kotlin/no/nav/emottak/cpa/nhn/adresseregisteret/DpopTokenUtil.kt
+++ b/cpa-repo/src/main/kotlin/no/nav/emottak/cpa/nhn/adresseregisteret/DpopTokenUtil.kt
@@ -13,10 +13,10 @@ import io.ktor.http.ContentType.Application.FormUrlEncoded
 import io.ktor.http.Parameters
 import io.ktor.http.contentType
 import io.ktor.http.formUrlEncode
-import no.nav.emottak.cpa.configuration.Config
+import no.nav.emottak.cpa.configuration.NhnOAuth
 
 class DpopTokenUtil(
-    private val config: Config,
+    private val nhnOAuth: NhnOAuth,
     private val jwtProvider: DpopJwtProvider,
     private val httpTokenClient: HttpClient
 ) {
@@ -45,16 +45,16 @@ class DpopTokenUtil(
     }
 
     private suspend fun tokenRequest(dpopProofWithNonce: String): HttpResponse =
-        httpTokenClient.post(config.nhnOAuth.tokenEndpoint.toString()) {
+        httpTokenClient.post(nhnOAuth.tokenEndpoint.toString()) {
             header(DPOP.value, dpopProofWithNonce)
             contentType(FormUrlEncoded)
             setBody(
                 Parameters.build {
-                    append("client_id", config.nhnOAuth.clientId.value)
-                    append("grant_type", config.nhnOAuth.grantType.value)
-                    append("scope", config.nhnOAuth.scope.value)
+                    append("client_id", nhnOAuth.clientId.value)
+                    append("grant_type", nhnOAuth.grantType.value)
+                    append("scope", nhnOAuth.scope.value)
                     append("client_assertion", jwtProvider.clientAssertion())
-                    append("client_assertion_type", config.nhnOAuth.clientAssertionType.value)
+                    append("client_assertion_type", nhnOAuth.clientAssertionType.value)
                 }
                     .formUrlEncode()
             )

--- a/cpa-repo/src/main/kotlin/no/nav/emottak/cpa/nhn/adresseregisteret/HttpClient.kt
+++ b/cpa-repo/src/main/kotlin/no/nav/emottak/cpa/nhn/adresseregisteret/HttpClient.kt
@@ -9,6 +9,8 @@ import io.ktor.client.request.header
 import io.ktor.http.HttpHeaders.Accept
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
+import no.nav.emottak.cpa.configuration.Nhn
+import no.nav.emottak.cpa.configuration.NhnOAuth
 import no.nav.emottak.cpa.configuration.config
 import no.nav.emottak.utils.environment.getEnvVar
 import java.net.InetSocketAddress
@@ -57,11 +59,12 @@ private fun httpClient(
     }
 }
 
-fun nhnArHttpClient(): HttpClient {
-    val config = config()
-
-    val dpopJwtProvider = DpopJwtProvider(config)
-    val dpopTokenUtil = DpopTokenUtil(config, dpopJwtProvider, httpTokenClient())
+fun nhnArHttpClient(
+    nhnOAuth: NhnOAuth = config.nhnOAuth,
+    nhn: Nhn = config.nhn
+): HttpClient {
+    val dpopJwtProvider = DpopJwtProvider(nhnOAuth, nhn)
+    val dpopTokenUtil = DpopTokenUtil(nhnOAuth, dpopJwtProvider, httpTokenClient())
 
     return httpClient(dpopJwtProvider, dpopTokenUtil)
 }

--- a/cpa-repo/src/main/kotlin/no/nav/emottak/cpa/nhn/adresseregisteret/HttpClient.kt
+++ b/cpa-repo/src/main/kotlin/no/nav/emottak/cpa/nhn/adresseregisteret/HttpClient.kt
@@ -61,9 +61,9 @@ private fun httpClient(
 
 fun nhnArHttpClient(
     nhnOAuth: NhnOAuth = config.nhnOAuth,
-    nhn: Nhn = config.nhn
+    nhnConfig: Nhn = config.nhn
 ): HttpClient {
-    val dpopJwtProvider = DpopJwtProvider(nhnOAuth, nhn)
+    val dpopJwtProvider = DpopJwtProvider(nhnOAuth, nhnConfig)
     val dpopTokenUtil = DpopTokenUtil(nhnOAuth, dpopJwtProvider, httpTokenClient())
 
     return httpClient(dpopJwtProvider, dpopTokenUtil)

--- a/cpa-repo/src/main/kotlin/no/nav/emottak/cpa/validation/AdresseregisterValidator.kt
+++ b/cpa-repo/src/main/kotlin/no/nav/emottak/cpa/validation/AdresseregisterValidator.kt
@@ -1,0 +1,44 @@
+package no.nav.emottak.cpa.validation
+
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import no.nav.emottak.cpa.configuration.Nhn
+import no.nav.emottak.cpa.configuration.config
+import no.nav.emottak.cpa.model.Certificate
+import no.nav.emottak.cpa.model.CommunicationParty
+
+class AdresseregisterValidator(
+    val httpClient: HttpClient,
+    nhnConfig: Nhn = config.nhn
+) {
+    private val cpapiCommunicationPartyUrl = nhnConfig.cpApiCommunicationPartyUrl
+    private val cpapiCertificateUrl = nhnConfig.cpApiCertificateUrl
+    val cpapiActive = nhnConfig.cpApiActive
+
+    suspend fun getCommunicationParty(herId: String): CommunicationParty =
+        httpClient.getDataFromArAPI("$cpapiCommunicationPartyUrl/$herId").body<CommunicationParty>()
+
+    suspend fun getSigningCertificate(herId: String): Certificate =
+        httpClient.getDataFromArAPI("$cpapiCertificateUrl/$herId/signing").body<Certificate>()
+
+    suspend fun getEncryptionCertificate(herId: String): Certificate =
+        httpClient.getDataFromArAPI("$cpapiCertificateUrl/$herId/encryption").body<Certificate>()
+
+    suspend fun getEdiAddress(herId: String): String? = getCommunicationParty(herId).ediAddress
+
+    private suspend fun HttpClient.getDataFromArAPI(endpointUrl: String): HttpResponse = try {
+        this.get(endpointUrl).also {
+            when (it.status) {
+                HttpStatusCode.OK -> log.debug("Data mottatt: ${it.bodyAsText()}")
+                else -> log.warn("Feil ved oppslag: ${it.status}")
+            }
+        }
+    } catch (e: Exception) {
+        log.error("Kunne ikke koble til $endpointUrl: ${e.localizedMessage}", e)
+        throw e
+    }
+}

--- a/cpa-repo/src/main/resources/application.conf
+++ b/cpa-repo/src/main/resources/application.conf
@@ -4,8 +4,10 @@ kafka {
 }
 
 nhn {
-  adresseregisterApiBaseUrl = "${ADRESSE_REGISTER_URL:-https://cpapi.test.grunndata.nhn.no/api/v1/communicationparty}"
-  adresseregisterApiCertificateBaseUrl = "${ADRESSE_REGISTER_CERTIFICATE_URL:-https://cpapi.test.grunndata.nhn.no/api/v1/certificate}"
+  cpApiBaseUrl = "${CPAPI_BASE_URL:-https://cpapi.test.grunndata.nhn.no}"
+  cpApiCommunicationPartyUrl = ${nhn.cpApiBaseUrl}"/api/v1/communicationparty"
+  cpApiCertificateUrl = ${nhn.cpApiBaseUrl}"/api/v1/certificate"
+  cpApiActive = "${CPAPI_ACTIVE:-true}"
   keyPairPath = "${NHN_KEYPAIR_PATH:-src/test/resources/keypair-jwk.json}"
 }
 
@@ -14,7 +16,7 @@ nhnOAuth  {
   clientId = "${NHN_CLIENT_ID:-1234}"
   audience = "${NHN_CLIENT_AUDIENCE:-https://helseid-sts.test.nhn.no}"
   tokenEndpoint = "${NHN_TOKEN_ENDPOINT:-https://helseid-sts.test.nhn.no/connect/token}"
-  scope = "${NHN_CLIENT_SCOPE:-nhn:cp-api/access-v2-dpop}"
+  scope = "${NHN_CLIENT_SCOPE:-nhn:communicationparty/read}"
   grantType = "${NHN_CLIENT_GRANT_TYPE:-client_credentials}"
   clientAssertionType = "${NHN_CLIENT_ASSERTION_TYPE:-urn:ietf:params:oauth:client-assertion-type:jwt-bearer}"
 }

--- a/cpa-repo/src/test/kotlin/no/nav/emottak/cpa/CPARepoIntegrationTest.kt
+++ b/cpa-repo/src/test/kotlin/no/nav/emottak/cpa/CPARepoIntegrationTest.kt
@@ -38,6 +38,7 @@ import no.nav.emottak.cpa.model.CommunicationParty
 import no.nav.emottak.cpa.persistence.CPARepository
 import no.nav.emottak.cpa.persistence.gammel.PartnerRepository
 import no.nav.emottak.cpa.util.EventRegistrationServiceFake
+import no.nav.emottak.cpa.validation.AdresseregisterValidator
 import no.nav.emottak.message.model.Direction.IN
 import no.nav.emottak.message.model.EmailAddress
 import no.nav.emottak.message.model.ErrorCode
@@ -51,7 +52,9 @@ import no.nav.emottak.message.model.ValidationRequest
 import no.nav.emottak.message.model.ValidationResult
 import no.nav.emottak.util.LENIENT_JSON_PARSER
 import no.nav.emottak.util.OSLO_ZONE
+import no.nav.emottak.util.createX509Certificate
 import no.nav.emottak.util.jsonLenient
+import no.nav.emottak.util.thumbprint
 import no.nav.emottak.utils.common.model.Addressing
 import no.nav.emottak.utils.common.model.Party
 import no.nav.emottak.utils.common.model.PartyId
@@ -88,11 +91,13 @@ class CPARepoIntegrationTest : PostgresOracleTest() {
                 postgres.dataSource,
                 oracle.dataSource,
                 eventRegistrationService,
-                HttpClient(getFakeNhnAdresseregisterEngine()) {
-                    install(ContentNegotiation) {
-                        jsonLenient()
+                AdresseregisterValidator(
+                    HttpClient(getFakeNhnAdresseregisterEngine()) {
+                        install(ContentNegotiation) {
+                            jsonLenient()
+                        }
                     }
-                }
+                )
             )
         )
         testBlock()
@@ -101,28 +106,31 @@ class CPARepoIntegrationTest : PostgresOracleTest() {
     private fun <T> validateCpaMockTestApp(testBlock: suspend ApplicationTestBuilder.() -> T) = testApplication {
         clearAllMocks()
 
-        val httpClient = createClient {
-            install(ContentNegotiation) {
-                jsonLenient()
+        val adresseregisterValidator = AdresseregisterValidator(
+            HttpClient(getFakeNhnAdresseregisterEngine()) {
+                install(ContentNegotiation) {
+                    jsonLenient()
+                }
             }
-        }
+        )
+
         cpaRepositoryMock = mockk()
         partnerRepositoryMock = mockk(relaxed = true)
-        application(validateCpaApplicationModule(cpaRepositoryMock, partnerRepositoryMock, httpClient))
+        application(validateCpaApplicationModule(cpaRepositoryMock, partnerRepositoryMock, adresseregisterValidator))
         testBlock()
     }
 
     private fun validateCpaApplicationModule(
         cpaRepository: CPARepository,
         partnerRepository: PartnerRepository,
-        httpdClient: HttpClient
+        adresseregisterValidator: AdresseregisterValidator
     ): Application.() -> Unit {
         return {
             install(io.ktor.server.plugins.contentnegotiation.ContentNegotiation) {
                 jsonLenient()
             }
             routing {
-                validateCpa(cpaRepository, partnerRepository, eventRegistrationService, httpdClient)
+                validateCpa(cpaRepository, partnerRepository, eventRegistrationService, adresseregisterValidator)
             }
         }
     }
@@ -230,7 +238,7 @@ class CPARepoIntegrationTest : PostgresOracleTest() {
         // assertTrue(validationResult.receiverEmailAddress.isEmpty()) // Channel-protokoll er HTTP
         assertEquals(1, validationResult.receiverEmailAddress.size)
         assertEquals("mailto://mottak-qass@test-es.nav.no", "mailto://" + validationResult.receiverEmailAddress.first().emailAddress)
-        assertEquals("mailto://meldingstjener-api@testedi.nhn.no", "mailto://" + validationResult.signalEmailAddress.first().emailAddress)
+        assertEquals("mailto://mottak-qass@test-es.nav.no", "mailto://" + validationResult.signalEmailAddress.first().emailAddress)
     }
 
     @Test
@@ -868,31 +876,6 @@ class CPARepoIntegrationTest : PostgresOracleTest() {
     }
 
     @Test
-    fun `messagingCharacteristics endpoint should return OK if CPA does not found`() = cpaRepoTestApp {
-        val httpClient = createClient {
-            install(ContentNegotiation) {
-                jsonLenient()
-            }
-        }
-
-        val messagingCharacteristicsRequest = MessagingCharacteristicsRequest(
-            requestId = Uuid.random().toString(),
-            cpaId = "no:such:cpa",
-            partyIds = listOf(PartyId("HER", "8141253")),
-            role = "Behandler",
-            service = "BehandlerKrav",
-            action = "OppgjorsMelding"
-        )
-
-        val response = httpClient.post("/cpa/messagingCharacteristics") {
-            setBody(messagingCharacteristicsRequest)
-            contentType(Json)
-        }
-
-        assertEquals(HttpStatusCode.OK, response.status)
-    }
-
-    @Test
     fun `Validate signature sertifikat from AR when Cpa does not exist`() = cpaRepoTestApp {
         val request = SignatureDetailsRequest(
             cpaId = "no:such:cpa", // TODO endres hvis/når respons fra getCpa ikke lenger er hardkodet
@@ -914,7 +897,9 @@ class CPARepoIntegrationTest : PostgresOracleTest() {
             contentType(Json)
         }
 
-        response.body<Certificate>()
+        val signatureDetails = response.body<SignatureDetails>()
+        val signingCertificate = createX509Certificate(signatureDetails.certificate)
+        assertEquals("6401DC7DE91E1DE1DAA58AB9F71B769C00578FA2", signingCertificate.thumbprint())
         assertEquals(HttpStatusCode.OK, response.status)
     }
 

--- a/felles/src/main/kotlin/no/nav/emottak/util/SertifikatUtil.kt
+++ b/felles/src/main/kotlin/no/nav/emottak/util/SertifikatUtil.kt
@@ -2,6 +2,7 @@ package no.nav.emottak.util
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import java.io.ByteArrayInputStream
+import java.security.MessageDigest
 import java.security.cert.CertificateException
 import java.security.cert.CertificateFactory
 import java.security.cert.X509CRL
@@ -26,3 +27,8 @@ fun createCRLFile(byteArray: ByteArray): X509CRL {
 }
 
 fun decodeBase64(base64String: ByteArray): ByteArray = java.util.Base64.getMimeDecoder().decode(base64String)
+
+fun X509Certificate.thumbprint(): String {
+    val digest = MessageDigest.getInstance("SHA-1")
+    return digest.digest(encoded).joinToString("") { "%02X".format(it) }
+}


### PR DESCRIPTION
- HTTP-kallene mot NHN adresseregisteret er samlet i en dedikert klasse. 
- Toggle for aktivering av CP-API. Ny miljøvariabel CPAPI_ACTIVE styrer om adresseregisteret skal brukes. I prod er den satt til false, i dev til true.
 - OAuth-scope er oppdatert til korrekt `nhn:communicationparty/read`
 - Dpop/HelseID auth tar nå NhnOAuth og Nhn som separate parametere i stedet for hele Config-objektet
 - Rydding i routes
 - Litt refaktorering.