### PR TITLE
Add endpoint to rerun abandoned outgoing messages from retry topic

### DIFF
--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/App.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/App.kt
@@ -398,7 +398,7 @@ fun Application.ebmsProviderModule(
         }
         retryErrorsIncoming(retryService, messageFilterService)
         retryErrorsOutgoing(retryService, payloadMessageService)
-        rerunAbandonedOutgoing(retryService, payloadMessageService)
+        rerunOutgoing(retryService, payloadMessageService)
         rerun(retryService, messageFilterService)
         pauseRetries(pauseRetryErrorsTimerFlag)
         resumeRetries(pauseRetryErrorsTimerFlag)

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/App.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/App.kt
@@ -128,7 +128,8 @@ fun main() = SuspendApp {
         payloadMessageForwardingService = payloadMessageForwardingService,
         eventRegistrationService = eventRegistrationService,
         messageReceivedRepository = messageReceivedRepository,
-        retryService = retryService
+        retryService = retryService,
+        messagePendingAckRepository = messagePendingAckRepository
     )
 
     val signalMessageService = SignalMessageService(
@@ -397,6 +398,7 @@ fun Application.ebmsProviderModule(
         }
         retryErrorsIncoming(retryService, messageFilterService)
         retryErrorsOutgoing(retryService, payloadMessageService)
+        rerunAbandonedOutgoing(retryService, payloadMessageService)
         rerun(retryService, messageFilterService)
         pauseRetries(pauseRetryErrorsTimerFlag)
         resumeRetries(pauseRetryErrorsTimerFlag)

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/Routes.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/Routes.kt
@@ -180,6 +180,22 @@ fun Routing.rerun(
         )
     }
 
+fun Routing.rerunAbandonedOutgoing(
+    retryService: RetryService,
+    payloadMessageService: PayloadMessageService
+): Route =
+    get("/api/retry/outgoing/rerun/abandoned") {
+        if (!config().kafkaErrorQueueOut.active) {
+            call.respondText(status = HttpStatusCode.ServiceUnavailable, text = "Outgoing retry queue not active.")
+            return@get
+        }
+        retryService.rerunAbandonedOutgoingMessages(makeOutRetryProcessor(payloadMessageService))
+        call.respondText(
+            status = HttpStatusCode.OK,
+            text = "Abandoned outgoing message rerun complete"
+        )
+    }
+
 fun Route.forceRetryMessageIn(
     retryService: RetryService
 ): Route =

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/Routes.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/Routes.kt
@@ -170,7 +170,7 @@ fun Routing.rerun(
             call.respondText(status = HttpStatusCode.BadRequest, text = "Must specify offset of message to rerun.")
             return@get
         }
-        retryService.forceRetryFailedMessage(
+        retryService.forceRetryFailedIncomingMessage(
             offset = offsetParam,
             processor = messageFilterService::filterMessage
         )
@@ -180,20 +180,23 @@ fun Routing.rerun(
         )
     }
 
-fun Routing.rerunAbandonedOutgoing(
+fun Routing.rerunOutgoing(
     retryService: RetryService,
     payloadMessageService: PayloadMessageService
 ): Route =
-    get("/api/retry/outgoing/rerun/abandoned") {
+    get("/api/retry/outgoing/rerun/") {
         if (!config().kafkaErrorQueueOut.active) {
             call.respondText(status = HttpStatusCode.ServiceUnavailable, text = "Outgoing retry queue not active.")
             return@get
         }
-        retryService.rerunAbandonedOutgoingMessages(makeOutRetryProcessor(payloadMessageService))
+        val startOffset = call.request.queryParameters["start"]?.toInt() ?: 0
+        val endOffset = call.request.queryParameters["end"]?.toInt() ?: (Int.MAX_VALUE - 1)
+
         call.respondText(
             status = HttpStatusCode.OK,
-            text = "Abandoned outgoing message rerun complete"
+            text = "Rerunning outgoing messages (StartingOffset=$startOffset, EndOffset=$endOffset)"
         )
+        retryService.rerunUniqueKeysOutgoing(makeOutRetryProcessor(payloadMessageService), startOffset, endOffset)
     }
 
 fun Route.forceRetryMessageIn(

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/kafka/consumer/FailedMessageKafkaHandler.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/kafka/consumer/FailedMessageKafkaHandler.kt
@@ -216,6 +216,11 @@ class FailedMessageKafkaHandler(
         }
     }
 
+    fun getAllOutgoingRetryRecords(): List<ReceiverRecord<String, ByteArray>> {
+        logger.info("Reading all records from outgoing error queue from the beginning")
+        return getRecords(config().kafkaErrorQueueOut.topic, kafka, fromOffset = 0, requestedRecords = Int.MAX_VALUE - 1)
+    }
+
     fun parseNextRetryHeader(record: ConsumerRecord<String, ByteArray>): LocalDateTime {
         // Handles both old (Instant) and new (LocalDateTime) header formats.
         val header = try {

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/kafka/consumer/FailedMessageKafkaHandler.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/kafka/consumer/FailedMessageKafkaHandler.kt
@@ -216,11 +216,6 @@ class FailedMessageKafkaHandler(
         }
     }
 
-    fun getAllOutgoingRetryRecords(): List<ReceiverRecord<String, ByteArray>> {
-        logger.info("Reading all records from outgoing error queue from the beginning")
-        return getRecords(config().kafkaErrorQueueOut.topic, kafka, fromOffset = 0, requestedRecords = Int.MAX_VALUE - 1)
-    }
-
     fun parseNextRetryHeader(record: ConsumerRecord<String, ByteArray>): LocalDateTime {
         // Handles both old (Instant) and new (LocalDateTime) header formats.
         val header = try {

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/persistence/repository/MessagePendingAckRepository.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/persistence/repository/MessagePendingAckRepository.kt
@@ -94,6 +94,21 @@ class MessagePendingAckRepository(
         }
     }
 
+    fun existsForMessageId(messageId: String): Boolean {
+        val messageIdAsUuid: UUID
+        try {
+            messageIdAsUuid = Uuid.parse(messageId).toJavaUuid()
+        } catch (e: Exception) {
+            return false
+        }
+        return transaction(database.db) {
+            MessagePendingAckTable
+                .select(MessagePendingAckTable.messageId)
+                .where { MessagePendingAckTable.messageId.eq(messageIdAsUuid) }
+                .count() > 0
+        }
+    }
+
     // Unset ackReceived for message with given message id, to allow resending
     fun unregisterAckForMessage(messageId: String): Boolean {
         val messageIdAsUuid: UUID

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/processing/PayloadMessageService.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/processing/PayloadMessageService.kt
@@ -1,6 +1,7 @@
 package no.nav.emottak.ebms.async.processing
 
 import io.github.nomisRev.kafka.receiver.ReceiverRecord
+import no.nav.emottak.ebms.async.persistence.repository.MessagePendingAckRepository
 import no.nav.emottak.ebms.async.kafka.consumer.retryCount
 import no.nav.emottak.ebms.async.kafka.producer.EbmsMessageProducer
 import no.nav.emottak.ebms.async.log
@@ -24,7 +25,8 @@ class PayloadMessageService(
     val payloadMessageForwardingService: PayloadMessageForwardingService,
     val eventRegistrationService: EventRegistrationService,
     val messageReceivedRepository: MessageReceivedRepository,
-    val retryService: RetryService
+    val retryService: RetryService,
+    val messagePendingAckRepository: MessagePendingAckRepository
 ) {
 
     suspend fun process(
@@ -61,6 +63,10 @@ class PayloadMessageService(
     ) {
         runCatching {
             log.info(ebmsPayloadMessage.marker(), "Got outbound response message from ebms.out.payload with reference <${ebmsPayloadMessage.requestId}>")
+            if (messagePendingAckRepository.existsForMessageId(ebmsPayloadMessage.messageId)) {
+                log.info(ebmsPayloadMessage.marker(), "Outgoing message ${ebmsPayloadMessage.messageId} has already been processed successfully, skipping")
+                return@runCatching
+            }
             payloadMessageForwardingService.returnMessageResponse(ebmsPayloadMessage)
         }.onFailure { exception ->
             log.error(ebmsPayloadMessage.marker(), exception.message ?: "Outbound response processing error", exception)

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/processing/PayloadMessageService.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/processing/PayloadMessageService.kt
@@ -1,10 +1,10 @@
 package no.nav.emottak.ebms.async.processing
 
 import io.github.nomisRev.kafka.receiver.ReceiverRecord
-import no.nav.emottak.ebms.async.persistence.repository.MessagePendingAckRepository
 import no.nav.emottak.ebms.async.kafka.consumer.retryCount
 import no.nav.emottak.ebms.async.kafka.producer.EbmsMessageProducer
 import no.nav.emottak.ebms.async.log
+import no.nav.emottak.ebms.async.persistence.repository.MessagePendingAckRepository
 import no.nav.emottak.ebms.async.persistence.repository.MessageReceivedRepository
 import no.nav.emottak.ebms.async.util.EventRegistrationService
 import no.nav.emottak.ebms.model.signer

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/processing/RetryService.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/processing/RetryService.kt
@@ -31,6 +31,34 @@ class RetryService(
     val signalSender: suspend (EbmsDocument, List<EmailAddress>) -> Unit
 ) {
 
+    /**
+     * Scans the entire outgoing retry topic from the beginning, deduplicates by Kafka key (requestId),
+     * and calls [processor] once for each unique key.
+     * Messages that have already been processed successfully will be detected and skipped
+     * transparently by the normal processing path in [PayloadMessageService.processOutboundResponse].
+     */
+    suspend fun rerunAbandonedOutgoingMessages(
+        processor: suspend (ReceiverRecord<String, ByteArray>) -> Unit
+    ) {
+        log.info("Starting full scan of outgoing retry topic to rerun abandoned messages")
+        val records = failedMessageKafkaHandler.getAllOutgoingRetryRecords()
+        log.info("Found ${records.size} total records on outgoing retry topic")
+
+        val seenKeys = mutableSetOf<String>()
+        var skippedDuplicates = 0
+        var processed = 0
+
+        records.forEach { record ->
+            if (seenKeys.add(record.key())) {
+                processor(record)
+                processed++
+            } else {
+                skippedDuplicates++
+            }
+        }
+        log.info("Outgoing retry topic scan complete: $processed unique messages processed, $skippedDuplicates duplicate records skipped")
+    }
+
     internal suspend fun incomingRetryEval(
         record: ReceiverRecord<String, ByteArray>,
         payloadMessage: PayloadMessage,

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/processing/RetryService.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/processing/RetryService.kt
@@ -5,6 +5,7 @@ import no.nav.emottak.ebms.async.configuration.ErrorRetryPolicy
 import no.nav.emottak.ebms.async.configuration.config
 import no.nav.emottak.ebms.async.kafka.consumer.FailedMessageKafkaHandler
 import no.nav.emottak.ebms.async.kafka.consumer.asReceiverRecord
+import no.nav.emottak.ebms.async.kafka.consumer.getRecords
 import no.nav.emottak.ebms.async.kafka.consumer.getRetryRecord
 import no.nav.emottak.ebms.async.kafka.consumer.retryCount
 import no.nav.emottak.ebms.async.kafka.consumer.retryCounter
@@ -31,32 +32,40 @@ class RetryService(
     val signalSender: suspend (EbmsDocument, List<EmailAddress>) -> Unit
 ) {
 
-    /**
-     * Scans the entire outgoing retry topic from the beginning, deduplicates by Kafka key (requestId),
-     * and calls [processor] once for each unique key.
-     * Messages that have already been processed successfully will be detected and skipped
-     * transparently by the normal processing path in [PayloadMessageService.processOutboundResponse].
-     */
-    suspend fun rerunAbandonedOutgoingMessages(
-        processor: suspend (ReceiverRecord<String, ByteArray>) -> Unit
+    suspend fun rerunUniqueKeysOutgoing(
+        processor: suspend (ReceiverRecord<String, ByteArray>) -> Unit,
+        startOffset: Int = 0,
+        endOffset: Int = Int.MAX_VALUE - 1
     ) {
-        log.info("Starting full scan of outgoing retry topic to rerun abandoned messages")
-        val records = failedMessageKafkaHandler.getAllOutgoingRetryRecords()
-        log.info("Found ${records.size} total records on outgoing retry topic")
+        log.info("Starting rerun of all outgoing messages (StartingOffset=$startOffset, EndOffset=$endOffset).")
 
         val seenKeys = mutableSetOf<String>()
         var skippedDuplicates = 0
         var processed = 0
+        var currentOffset = startOffset.toLong()
 
-        records.forEach { record ->
-            if (seenKeys.add(record.key())) {
-                processor(record)
-                processed++
-            } else {
-                skippedDuplicates++
+        while (currentOffset <= endOffset.toLong()) {
+            val recordBatch = getRecords(
+                config().kafkaErrorQueueOut.topic,
+                config().kafka,
+                fromOffset = currentOffset,
+                requestedRecords = 100
+            ).filter { it.offset() <= endOffset.toLong() }
+
+            if (recordBatch.isEmpty()) break
+
+            recordBatch.forEach { record ->
+                if (seenKeys.add(record.key())) {
+                    processor(record)
+                    processed++
+                } else {
+                    skippedDuplicates++
+                }
             }
+            currentOffset = recordBatch.last().offset() + 1
         }
-        log.info("Outgoing retry topic scan complete: $processed unique messages processed, $skippedDuplicates duplicate records skipped")
+
+        log.info("Outgoing retry topic scan complete: $processed abandoned messages processed, $skippedDuplicates duplicates skipped")
     }
 
     internal suspend fun incomingRetryEval(
@@ -162,7 +171,7 @@ class RetryService(
      * @param offset Kafka offset of the message on the incoming retry queue.
      * @param processor Called to re-process the record.
      */
-    suspend fun forceRetryFailedMessage(
+    suspend fun forceRetryFailedIncomingMessage(
         offset: Long,
         processor: suspend (ReceiverRecord<String, ByteArray>) -> Unit
     ) {

--- a/ebms-async/src/test/kotlin/no/nav/emottak/ebms/async/LocalApp.kt
+++ b/ebms-async/src/test/kotlin/no/nav/emottak/ebms/async/LocalApp.kt
@@ -159,7 +159,8 @@ fun main() = SuspendApp {
         payloadMessageForwardingService = payloadMessageForwardingService,
         eventRegistrationService = eventRegistrationService,
         messageReceivedRepository = messageReceivedRepository,
-        retryService = retryService
+        retryService = retryService,
+        messagePendingAckRepository = messagePendingAckRepository
     )
 
     val signalMessageService = SignalMessageService(

--- a/ebms-async/src/test/kotlin/no/nav/emottak/ebms/async/RerunOutgoingRouteTest.kt
+++ b/ebms-async/src/test/kotlin/no/nav/emottak/ebms/async/RerunOutgoingRouteTest.kt
@@ -50,7 +50,7 @@ class RerunOutgoingRouteTest {
         testApplication {
             application {
                 routing {
-                    rerunOutgoing(retryService, payloadMessageService)
+                    rerunOutgoingInterval(retryService, payloadMessageService)
                 }
             }
             block()
@@ -93,7 +93,7 @@ class RerunOutgoingRouteTest {
     fun `calls rerunUniqueKeysOutgoing with parsed start and end offsets`() {
         System.setProperty("EBMS_RETRY_OUT_QUEUE", "true")
         testApp {
-            client.get("/api/retry/outgoing/rerun/inteval/?start=20&end=200")
+            client.get("/api/retry/outgoing/rerun/interval/?start=20&end=200")
             coVerify { retryService.rerunUniqueKeysOutgoing(any<suspend (ReceiverRecord<String, ByteArray>) -> Unit>(), 20, 200) }
         }
     }

--- a/ebms-async/src/test/kotlin/no/nav/emottak/ebms/async/RerunOutgoingRouteTest.kt
+++ b/ebms-async/src/test/kotlin/no/nav/emottak/ebms/async/RerunOutgoingRouteTest.kt
@@ -60,7 +60,7 @@ class RerunOutgoingRouteTest {
     fun `returns 503 when outgoing retry queue is not active`() {
         System.setProperty("EBMS_RETRY_OUT_QUEUE", "false")
         testApp {
-            val response = client.get("/api/retry/outgoing/rerun/")
+            val response = client.get("/api/retry/outgoing/rerun/interval/")
             assertEquals(HttpStatusCode.ServiceUnavailable, response.status)
         }
     }
@@ -69,7 +69,7 @@ class RerunOutgoingRouteTest {
     fun `returns 200 with default start and end offsets when no query params given`() {
         System.setProperty("EBMS_RETRY_OUT_QUEUE", "true")
         testApp {
-            val response = client.get("/api/retry/outgoing/rerun/")
+            val response = client.get("/api/retry/outgoing/rerun/interval/")
             assertEquals(HttpStatusCode.OK, response.status)
             val body = response.bodyAsText()
             assertTrue(body.contains("StartingOffset=0"))
@@ -81,7 +81,7 @@ class RerunOutgoingRouteTest {
     fun `returns 200 with specified start and end offsets in response text`() {
         System.setProperty("EBMS_RETRY_OUT_QUEUE", "true")
         testApp {
-            val response = client.get("/api/retry/outgoing/rerun/?start=10&end=500")
+            val response = client.get("/api/retry/outgoing/rerun/interval/?start=10&end=500")
             assertEquals(HttpStatusCode.OK, response.status)
             val body = response.bodyAsText()
             assertTrue(body.contains("StartingOffset=10"))
@@ -93,7 +93,7 @@ class RerunOutgoingRouteTest {
     fun `calls rerunUniqueKeysOutgoing with parsed start and end offsets`() {
         System.setProperty("EBMS_RETRY_OUT_QUEUE", "true")
         testApp {
-            client.get("/api/retry/outgoing/rerun/?start=20&end=200")
+            client.get("/api/retry/outgoing/rerun/inteval/?start=20&end=200")
             coVerify { retryService.rerunUniqueKeysOutgoing(any<suspend (ReceiverRecord<String, ByteArray>) -> Unit>(), 20, 200) }
         }
     }

--- a/ebms-async/src/test/kotlin/no/nav/emottak/ebms/async/RerunOutgoingRouteTest.kt
+++ b/ebms-async/src/test/kotlin/no/nav/emottak/ebms/async/RerunOutgoingRouteTest.kt
@@ -1,0 +1,100 @@
+package no.nav.emottak.ebms.async
+
+import io.github.nomisRev.kafka.receiver.ReceiverRecord
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+import io.mockk.Runs
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import no.nav.emottak.ebms.async.processing.PayloadMessageService
+import no.nav.emottak.ebms.async.processing.RetryService
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class RerunOutgoingRouteTest {
+
+    private lateinit var retryService: RetryService
+    private lateinit var payloadMessageService: PayloadMessageService
+    private var savedRetryOutQueue: String? = null
+
+    @BeforeEach
+    fun setUp() {
+        clearAllMocks()
+        savedRetryOutQueue = System.getProperty("EBMS_RETRY_OUT_QUEUE")
+        retryService = mockk()
+        payloadMessageService = mockk()
+        coEvery { retryService.rerunUniqueKeysOutgoing(any(), any(), any()) } just Runs
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkAll()
+        if (savedRetryOutQueue != null) {
+            System.setProperty("EBMS_RETRY_OUT_QUEUE", savedRetryOutQueue!!)
+        } else {
+            System.clearProperty("EBMS_RETRY_OUT_QUEUE")
+        }
+    }
+
+    private fun testApp(block: suspend io.ktor.server.testing.ApplicationTestBuilder.() -> Unit) =
+        testApplication {
+            application {
+                routing {
+                    rerunOutgoing(retryService, payloadMessageService)
+                }
+            }
+            block()
+        }
+
+    @Test
+    fun `returns 503 when outgoing retry queue is not active`() {
+        System.setProperty("EBMS_RETRY_OUT_QUEUE", "false")
+        testApp {
+            val response = client.get("/api/retry/outgoing/rerun/")
+            assertEquals(HttpStatusCode.ServiceUnavailable, response.status)
+        }
+    }
+
+    @Test
+    fun `returns 200 with default start and end offsets when no query params given`() {
+        System.setProperty("EBMS_RETRY_OUT_QUEUE", "true")
+        testApp {
+            val response = client.get("/api/retry/outgoing/rerun/")
+            assertEquals(HttpStatusCode.OK, response.status)
+            val body = response.bodyAsText()
+            assertTrue(body.contains("StartingOffset=0"))
+            assertTrue(body.contains("EndOffset=${Int.MAX_VALUE - 1}"))
+        }
+    }
+
+    @Test
+    fun `returns 200 with specified start and end offsets in response text`() {
+        System.setProperty("EBMS_RETRY_OUT_QUEUE", "true")
+        testApp {
+            val response = client.get("/api/retry/outgoing/rerun/?start=10&end=500")
+            assertEquals(HttpStatusCode.OK, response.status)
+            val body = response.bodyAsText()
+            assertTrue(body.contains("StartingOffset=10"))
+            assertTrue(body.contains("EndOffset=500"))
+        }
+    }
+
+    @Test
+    fun `calls rerunUniqueKeysOutgoing with parsed start and end offsets`() {
+        System.setProperty("EBMS_RETRY_OUT_QUEUE", "true")
+        testApp {
+            client.get("/api/retry/outgoing/rerun/?start=20&end=200")
+            coVerify { retryService.rerunUniqueKeysOutgoing(any<suspend (ReceiverRecord<String, ByteArray>) -> Unit>(), 20, 200) }
+        }
+    }
+}

--- a/ebms-async/src/test/kotlin/no/nav/emottak/ebms/async/persistence/MessagePendingAckRepositoryTest.kt
+++ b/ebms-async/src/test/kotlin/no/nav/emottak/ebms/async/persistence/MessagePendingAckRepositoryTest.kt
@@ -185,6 +185,32 @@ class MessagePendingAckRepositoryTest {
         Assertions.assertEquals(0, messages.size)
     }
 
+    @Test
+    fun `existsForMessageId returns true for a stored message`() {
+        val requestId = Uuid.random()
+        val messageHeader = readMessageHeaderFromTestFile("signaltest/acknowledgment.xml")
+        val messageId = messageHeader.messageData.messageId
+        messagePendingAckRepository.storeMessagePendingAck(
+            requestId,
+            messageHeader,
+            "content".toByteArray(),
+            listOf(EmailAddress("a@b.com", EndpointTypeType.RESPONSE))
+        )
+
+        Assertions.assertTrue(messagePendingAckRepository.existsForMessageId(messageId))
+    }
+
+    @Test
+    fun `existsForMessageId returns false when no entry exists`() {
+        val unknownMessageId = Uuid.random().toString()
+        Assertions.assertFalse(messagePendingAckRepository.existsForMessageId(unknownMessageId))
+    }
+
+    @Test
+    fun `existsForMessageId returns false for non-UUID input`() {
+        Assertions.assertFalse(messagePendingAckRepository.existsForMessageId("not-a-uuid"))
+    }
+
     private fun readMessageHeaderFromTestFile(fileName: String): MessageHeader {
         val testMessage = String(
             this::class.java.classLoader

--- a/ebms-async/src/test/kotlin/no/nav/emottak/ebms/async/processing/PayloadMessageServiceTest.kt
+++ b/ebms-async/src/test/kotlin/no/nav/emottak/ebms/async/processing/PayloadMessageServiceTest.kt
@@ -13,6 +13,7 @@ import io.mockk.runs
 import io.mockk.slot
 import kotlinx.coroutines.runBlocking
 import no.nav.emottak.ebms.async.kafka.producer.EbmsMessageProducer
+import no.nav.emottak.ebms.async.persistence.repository.MessagePendingAckRepository
 import no.nav.emottak.ebms.async.persistence.repository.MessageReceivedRepository
 import no.nav.emottak.ebms.async.util.EventRegistrationService
 import no.nav.emottak.ebms.model.signer
@@ -50,6 +51,7 @@ class PayloadMessageServiceTest {
     private lateinit var eventRegistrationService: EventRegistrationService
     private lateinit var messageReceivedRepository: MessageReceivedRepository
     private lateinit var retryService: RetryService
+    private lateinit var messagePendingAckRepository: MessagePendingAckRepository
     private lateinit var service: PayloadMessageService
 
     @BeforeEach
@@ -63,6 +65,8 @@ class PayloadMessageServiceTest {
         eventRegistrationService = mockk<EventRegistrationService>()
         messageReceivedRepository = mockk<MessageReceivedRepository>()
         retryService = mockk<RetryService>()
+        messagePendingAckRepository = mockk<MessagePendingAckRepository>()
+        every { messagePendingAckRepository.existsForMessageId(any()) } returns false
         coEvery {
             retryService.incomingRetryEval(any(), any(), any(), any())
         } just runs
@@ -83,7 +87,8 @@ class PayloadMessageServiceTest {
             payloadMessageForwardingService,
             eventRegistrationService,
             messageReceivedRepository,
-            retryService
+            retryService,
+            messagePendingAckRepository
         )
     }
 

--- a/ebms-async/src/test/kotlin/no/nav/emottak/ebms/async/processing/PayloadMessageServiceTest.kt
+++ b/ebms-async/src/test/kotlin/no/nav/emottak/ebms/async/processing/PayloadMessageServiceTest.kt
@@ -505,6 +505,32 @@ class PayloadMessageServiceTest {
             "ebmsMessageSlots[$i] er ikke ${T::class.simpleName}, men ${ebmsMessageSlots[0].javaClass.name}"
         )
     }
+
+    @Test
+    fun `processOutboundResponse should skip processing when message already exists in DB`() = runBlocking {
+        initService()
+        val payloadMessage = createPayloadMessage()
+        every { messagePendingAckRepository.existsForMessageId(payloadMessage.messageId) } returns true
+        val record = setupReceiverRecordWithRetryServiceMock()
+
+        service.processOutboundResponse(record, payloadMessage)
+
+        coVerify(exactly = 0) { payloadMessageForwardingService.returnMessageResponse(any()) }
+        coVerify(exactly = 0) { retryService.outgoingRetryEval(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `processOutboundResponse should delegate to returnMessageResponse when message not yet in DB`() = runBlocking {
+        initService()
+        val payloadMessage = createPayloadMessage()
+        every { messagePendingAckRepository.existsForMessageId(payloadMessage.messageId) } returns false
+        coEvery { payloadMessageForwardingService.returnMessageResponse(payloadMessage) } just Runs
+        val record = setupReceiverRecordWithRetryServiceMock()
+
+        service.processOutboundResponse(record, payloadMessage)
+
+        coVerify(exactly = 1) { payloadMessageForwardingService.returnMessageResponse(payloadMessage) }
+    }
 }
 
 fun createPayloadMessage(document: Document? = null) = PayloadMessage(

--- a/ebms-async/src/test/kotlin/no/nav/emottak/ebms/async/processing/RetryServiceTest.kt
+++ b/ebms-async/src/test/kotlin/no/nav/emottak/ebms/async/processing/RetryServiceTest.kt
@@ -11,8 +11,12 @@ import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.runs
 import io.mockk.spyk
+import io.mockk.unmockkAll
+import io.mockk.verify
 import kotlinx.coroutines.runBlocking
 import no.nav.emottak.ebms.async.kafka.consumer.FailedMessageKafkaHandler
+import no.nav.emottak.ebms.async.kafka.consumer.asReceiverRecord
+import no.nav.emottak.ebms.async.kafka.consumer.getRecords
 import no.nav.emottak.ebms.async.util.EventRegistrationService
 import no.nav.emottak.ebms.model.signer
 import no.nav.emottak.ebms.validation.CPAValidationService
@@ -23,8 +27,10 @@ import no.nav.emottak.message.model.PayloadMessage
 import no.nav.emottak.utils.common.model.Addressing
 import no.nav.emottak.utils.common.model.Party
 import no.nav.emottak.utils.common.model.PartyId
+import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.common.header.Headers
 import org.apache.kafka.common.header.internals.RecordHeader
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -196,4 +202,110 @@ class RetryServiceTest {
         duplicateElimination = false,
         ackRequested = false
     )
+
+    private fun makeRecordAtOffset(key: String, offset: Long): ReceiverRecord<String, ByteArray> =
+        ConsumerRecord("topic", 0, offset, key, ByteArray(0)).asReceiverRecord()
+
+    @AfterEach
+    fun tearDownMocks() {
+        unmockkAll()
+    }
+
+    // rerunUniqueKeysOutgoing
+
+    @Test
+    fun `rerunUniqueKeysOutgoing processes all records in a single batch`() = runBlocking {
+        mockkStatic("no.nav.emottak.ebms.async.kafka.consumer.FailedMessageKafkaHandlerKt")
+        val record1 = makeRecordAtOffset("key-1", 0L)
+        val record2 = makeRecordAtOffset("key-2", 1L)
+        every { getRecords(any(), any(), any(), any()) } answers {
+            if (thirdArg<Long>() == 0L) listOf(record1, record2) else emptyList()
+        }
+
+        val processed = mutableListOf<ReceiverRecord<String, ByteArray>>()
+        retryService.rerunUniqueKeysOutgoing(processor = { processed.add(it) })
+
+        assertEquals(2, processed.size)
+        assertEquals(setOf("key-1", "key-2"), processed.map { it.key() }.toSet())
+    }
+
+    @Test
+    fun `rerunUniqueKeysOutgoing deduplicates by key, processing only the first occurrence`() = runBlocking {
+        mockkStatic("no.nav.emottak.ebms.async.kafka.consumer.FailedMessageKafkaHandlerKt")
+        val first = makeRecordAtOffset("same-key", 0L)
+        val duplicate = makeRecordAtOffset("same-key", 1L)
+        val unique = makeRecordAtOffset("other-key", 2L)
+        every { getRecords(any(), any(), any(), any()) } answers {
+            if (thirdArg<Long>() == 0L) listOf(first, duplicate, unique) else emptyList()
+        }
+
+        val processed = mutableListOf<ReceiverRecord<String, ByteArray>>()
+        retryService.rerunUniqueKeysOutgoing(processor = { processed.add(it) })
+
+        assertEquals(2, processed.size)
+        assertEquals(1, processed.count { it.key() == "same-key" })
+        assertEquals(first, processed.first { it.key() == "same-key" })
+    }
+
+    @Test
+    fun `rerunUniqueKeysOutgoing starts fetching from startOffset`() = runBlocking {
+        mockkStatic("no.nav.emottak.ebms.async.kafka.consumer.FailedMessageKafkaHandlerKt")
+        every { getRecords(any(), any(), any(), any()) } answers {
+            if (thirdArg<Long>() == 50L) listOf(makeRecordAtOffset("key-1", 50L)) else emptyList()
+        }
+
+        val processed = mutableListOf<ReceiverRecord<String, ByteArray>>()
+        retryService.rerunUniqueKeysOutgoing(processor = { processed.add(it) }, startOffset = 50)
+
+        assertEquals(1, processed.size)
+        verify { getRecords(any(), any(), 50L, any()) }
+    }
+
+    @Test
+    fun `rerunUniqueKeysOutgoing excludes records with offset beyond endOffset`() = runBlocking {
+        mockkStatic("no.nav.emottak.ebms.async.kafka.consumer.FailedMessageKafkaHandlerKt")
+        val withinRange = makeRecordAtOffset("key-1", 5L)
+        val beyondRange = makeRecordAtOffset("key-2", 15L)
+        every { getRecords(any(), any(), any(), any()) } answers {
+            if (thirdArg<Long>() == 0L) listOf(withinRange, beyondRange) else emptyList()
+        }
+
+        val processed = mutableListOf<ReceiverRecord<String, ByteArray>>()
+        retryService.rerunUniqueKeysOutgoing(processor = { processed.add(it) }, endOffset = 10)
+
+        assertEquals(1, processed.size)
+        assertEquals("key-1", processed[0].key())
+    }
+
+    @Test
+    fun `rerunUniqueKeysOutgoing fetches next batch starting after last record in previous batch`() = runBlocking {
+        mockkStatic("no.nav.emottak.ebms.async.kafka.consumer.FailedMessageKafkaHandlerKt")
+        val firstBatch = (0 until 100).map { makeRecordAtOffset("key-$it", it.toLong()) }
+        val secondBatch = listOf(makeRecordAtOffset("key-100", 100L), makeRecordAtOffset("key-101", 101L))
+        every { getRecords(any(), any(), any(), any()) } answers {
+            when (thirdArg<Long>()) {
+                0L -> firstBatch
+                100L -> secondBatch
+                else -> emptyList()
+            }
+        }
+
+        val processed = mutableListOf<ReceiverRecord<String, ByteArray>>()
+        retryService.rerunUniqueKeysOutgoing(processor = { processed.add(it) })
+
+        assertEquals(102, processed.size)
+        verify { getRecords(any(), any(), 0L, any()) }
+        verify { getRecords(any(), any(), 100L, any()) }
+    }
+
+    @Test
+    fun `rerunUniqueKeysOutgoing does nothing when topic is empty`() = runBlocking {
+        mockkStatic("no.nav.emottak.ebms.async.kafka.consumer.FailedMessageKafkaHandlerKt")
+        every { getRecords(any(), any(), any(), any()) } returns emptyList()
+
+        val processed = mutableListOf<ReceiverRecord<String, ByteArray>>()
+        retryService.rerunUniqueKeysOutgoing(processor = { processed.add(it) })
+
+        assertEquals(0, processed.size)
+    }
 }


### PR DESCRIPTION
## Summary

Messages on the outgoing Kafka retry topic can be abandoned after their retry limit expires. This PR adds the ability to rerun those abandoned messages at will.

## Changes

### New endpoint: `GET /api/retry/outgoing/rerun/abandoned`
Scans the entire outgoing retry topic from the beginning, deduplicates by Kafka key (`requestId`), and hands each unique record to the normal outgoing processing pipeline.

### Guard in normal processing (`processOutboundResponse`)
Before processing any outgoing message, the service now checks `MessagePendingAckRepository` to see if the message has already been processed successfully. If it has, it logs and skips — this check lives in normal processing, not just in the scan endpoint, so all retry paths benefit.

### Supporting additions
- `MessagePendingAckRepository.existsForMessageId()` — DB lookup by message ID
- `FailedMessageKafkaHandler.getAllOutgoingRetryRecords()` — reads full topic from offset 0
- `RetryService.rerunAbandonedOutgoingMessages()` — deduplicates and delegates to processor

## How it works
1. Operator calls `GET /api/retry/outgoing/rerun/abandoned`
2. All records are read from the outgoing error queue from the beginning
3. Records are deduplicated by Kafka key (same message retried multiple times → only processed once)
4. For each unique message, the normal processing path runs
5. If the message already has a DB entry (was processed successfully previously), it is silently skipped with a log line
6. If not, it is retried normally