### PR TITLE
Skipper retry for feil som ikke er recoverable

### DIFF
--- a/cpa-repo/src/main/kotlin/no/nav/emottak/cpa/cert/CertificateValidationException.kt
+++ b/cpa-repo/src/main/kotlin/no/nav/emottak/cpa/cert/CertificateValidationException.kt
@@ -4,4 +4,9 @@ import no.nav.emottak.message.exception.EbmsException
 import no.nav.emottak.message.model.ErrorCode
 import org.oasis_open.committees.ebxml_msg.schema.msg_header_2_0.SeverityType
 
-class CertificateValidationException(message: String, exception: Exception? = null) : EbmsException(message, ErrorCode.SECURITY_FAILURE, SeverityType.ERROR.value()!!, exception)
+class CertificateValidationException(message: String, exception: Exception? = null) : EbmsException(
+    message = message,
+    errorCode = ErrorCode.SECURITY_FAILURE,
+    severity = SeverityType.ERROR.value()!!,
+    exception = exception
+)

--- a/cpa-repo/src/main/kotlin/no/nav/emottak/cpa/feil/Exceptions.kt
+++ b/cpa-repo/src/main/kotlin/no/nav/emottak/cpa/feil/Exceptions.kt
@@ -9,14 +9,24 @@ open class CpaValidationException(
     errorCode: ErrorCode = ErrorCode.DELIVERY_FAILURE,
     severity: String = SeverityType.ERROR.value(),
     exception: Exception? = null
-) : EbmsException(message, errorCode, severity, exception)
+) : EbmsException(
+    message = message,
+    errorCode = errorCode,
+    severity = severity,
+    exception = exception
+)
 
 open class SecurityException(
     message: String,
     errorCode: ErrorCode = ErrorCode.SECURITY_FAILURE,
     severity: String = SeverityType.ERROR.value(),
     exception: java.lang.Exception? = null
-) : EbmsException(message, errorCode, severity, exception)
+) : EbmsException(
+    message = message,
+    errorCode = errorCode,
+    severity = severity,
+    exception = exception
+)
 
 open class PartnerNotFoundException(
     message: String,

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/processing/RetryService.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/processing/RetryService.kt
@@ -18,6 +18,7 @@ import no.nav.emottak.message.model.Direction
 import no.nav.emottak.message.model.EbmsDocument
 import no.nav.emottak.message.model.EbmsMessage
 import no.nav.emottak.message.model.EmailAddress
+import no.nav.emottak.message.model.ErrorCode
 import no.nav.emottak.message.model.PayloadMessage
 import no.nav.emottak.util.marker
 import org.apache.kafka.clients.consumer.ConsumerRecord
@@ -42,7 +43,8 @@ class RetryService(
         val (decision, reason) = decideRetry(
             ttl = payloadMessage.timeToLive,
             retriedAlready = retryCount,
-            maxRetries = config().errorRetryPolicyIncoming.maxRetries
+            maxRetries = config().errorRetryPolicyIncoming.maxRetries,
+            exception
         )
         when (decision) {
             RetryDecision.RETRY -> failedMessageKafkaHandler.sendToRetryQueueIncoming(record, retryReason, getNextRetryTime(record, config().errorRetryPolicyIncoming))
@@ -51,7 +53,7 @@ class RetryService(
                     payloadMessage,
                     EbmsException(
                         "TimeToLive expired",
-                        errorCode = no.nav.emottak.message.model.ErrorCode.TIME_TO_LIVE_EXPIRED,
+                        errorCode = ErrorCode.TIME_TO_LIVE_EXPIRED,
                         exception = exception
                     )
                 )
@@ -61,9 +63,14 @@ class RetryService(
                     exception as? EbmsException
                         ?: EbmsException(
                             "Max Retries expired",
-                            errorCode = no.nav.emottak.message.model.ErrorCode.DELIVERY_FAILURE,
+                            errorCode = ErrorCode.DELIVERY_FAILURE,
                             exception = exception
                         )
+                )
+            RetryDecision.NO_RETRY ->
+                returnMessageError(
+                    payloadMessage,
+                    exception as EbmsException
                 )
         }
         log.info("Decision [$decision]:\n" + "Failing payload sent at ${payloadMessage.sentAt ?: "unknown"}, error type: ${exception::class.simpleName ?: "Unknown error"}, reason: $retryReason, retries already performed: $retryCount. Decision reason: $reason")
@@ -79,12 +86,14 @@ class RetryService(
         val (decision, reason) = decideRetry(
             ttl = payloadMessage.timeToLive,
             retriedAlready = retryCount,
-            maxRetries = config().errorRetryPolicyOutgoing.maxRetries
+            maxRetries = config().errorRetryPolicyOutgoing.maxRetries,
+            exception
         )
         when (decision) {
             RetryDecision.RETRY -> failedMessageKafkaHandler.sendToRetryQueueOutgoing(record, retryReason, getNextRetryTime(record, config().errorRetryPolicyOutgoing))
             RetryDecision.TTL_EXPIRED -> log.error(payloadMessage.marker(), "ebXML TimeToLive expired for outgoing message", exception)
-            RetryDecision.MAX_RETRIES_EXCEEDED -> log.error(payloadMessage.marker(), "ebXML Max Retires exhausted for outgoing message", exception)
+            RetryDecision.MAX_RETRIES_EXCEEDED -> log.error(payloadMessage.marker(), "ebXML Max Retries exhausted for outgoing message", exception)
+            RetryDecision.NO_RETRY -> log.error(payloadMessage.marker(), "Unrecoverable error occured", exception)
         }
         log.info("Decision [$decision]:\n" + "Failing outgoing payload sent at ${payloadMessage.sentAt ?: "unknown"}, error type: ${exception::class.simpleName ?: "Unknown error"}, reason: $retryReason, retries already performed: $retryCount. Decision reason: $reason")
     }
@@ -204,22 +213,17 @@ class RetryService(
         return LocalDateTime.now().plus(nextInterval.toJavaDuration()).toString()
     }
 
-    internal fun decideRetry(ttl: Instant?, retriedAlready: Int, maxRetries: Int): Pair<RetryDecision, String> {
-        if (ttl != null && isExpired(ttl)) {
-            return RetryDecision.TTL_EXPIRED to "ebXML TimeToLive expired at $ttl"
+    internal fun decideRetry(ttl: Instant?, retriedAlready: Int, maxRetries: Int, throwable: Throwable? = null): Pair<RetryDecision, String> {
+        return when {
+            throwable?.isRecoverableException() == false -> RetryDecision.NO_RETRY to "Unrecoverable exception type ${throwable::class.simpleName}, not retrying"
+            (ttl != null && isExpired(ttl)) -> RetryDecision.TTL_EXPIRED to "ebXML TimeToLive expired at $ttl"
+            (retriedAlready >= maxRetries) -> RetryDecision.MAX_RETRIES_EXCEEDED to "Retried too many times, max number is $maxRetries, already retried $retriedAlready times"
+            (ttl != null) -> RetryDecision.RETRY to "Within ebXML TimeToLive (expires at $ttl), already retried $retriedAlready times"
+            else -> RetryDecision.RETRY to "No ebXML TimeToLive but more retries OK, already retried $retriedAlready times"
         }
-        if (retriedAlready >= maxRetries) {
-            return RetryDecision.MAX_RETRIES_EXCEEDED to "Retried too many times, max number is $maxRetries, already retried $retriedAlready times"
-        }
-        val reason = if (ttl != null) {
-            "Within ebXML TimeToLive (expires at $ttl), already retried $retriedAlready times"
-        } else {
-            "No ebXML TimeToLive but more retries OK, already retried $retriedAlready times"
-        }
-        return RetryDecision.RETRY to reason
     }
 
-    internal enum class RetryDecision { RETRY, TTL_EXPIRED, MAX_RETRIES_EXCEEDED }
+    internal enum class RetryDecision { RETRY, TTL_EXPIRED, MAX_RETRIES_EXCEEDED, NO_RETRY }
 
     internal fun isExpired(ttl: Instant): Boolean {
         return ttl <= Instant.now()
@@ -245,3 +249,5 @@ class RetryService(
         const val AGE_DAYS_TO_IGNORE = 7L
     }
 }
+
+private fun Throwable?.isRecoverableException(): Boolean = (this as? EbmsException)?.isRecoverable() ?: true

--- a/ebms-async/src/test/kotlin/no/nav/emottak/ebms/async/processing/RetryServiceTest.kt
+++ b/ebms-async/src/test/kotlin/no/nav/emottak/ebms/async/processing/RetryServiceTest.kt
@@ -123,6 +123,48 @@ class RetryServiceTest {
     }
 
     @Test
+    fun `decideRetry returns NO_RETRY when exception is unrecoverable`() {
+        val unrecoverable = EbmsException("Dekryptering feilet", recoverable = false)
+        val (decision, reason) = retryService.decideRetry(ttl = null, retriedAlready = 0, maxRetries = 5, throwable = unrecoverable)
+        assertEquals(RetryService.RetryDecision.NO_RETRY, decision)
+        assertTrue(reason.contains("EbmsException"))
+    }
+
+    @Test
+    fun `decideRetry returns NO_RETRY for unrecoverable exception even when ttl is valid and retries remain`() {
+        val future = Instant.now().plusSeconds(3600)
+        val unrecoverable = EbmsException("Dekryptering feilet", recoverable = false)
+        val (decision, _) = retryService.decideRetry(ttl = future, retriedAlready = 0, maxRetries = 5, throwable = unrecoverable)
+        assertEquals(RetryService.RetryDecision.NO_RETRY, decision)
+    }
+
+    @Test
+    fun `decideRetry does not return NO_RETRY for recoverable exception`() {
+        val recoverable = EbmsException("Midlertidig feil", recoverable = true)
+        val (decision, _) = retryService.decideRetry(ttl = null, retriedAlready = 0, maxRetries = 5, throwable = recoverable)
+        assertEquals(RetryService.RetryDecision.RETRY, decision)
+    }
+
+    @Test
+    fun `incomingRetryEval does not retry and returns MessageError when exception is unrecoverable`() = runBlocking {
+        val receiverRecord = mockk<ReceiverRecord<String, ByteArray>>(relaxed = true)
+        val headers = mockk<Headers>()
+        every { receiverRecord.headers() } returns headers
+        every { headers.lastHeader("retryCount") } returns null
+
+        val payload = createPayloadMessageWithTtl(Instant.now().plusSeconds(3600))
+        val unrecoverable = EbmsException("Dekryptering feilet", recoverable = false)
+
+        val spyService = spyk(retryService)
+        coEvery { spyService.returnMessageError(any(), any()) } just Runs
+
+        spyService.incomingRetryEval(receiverRecord, payload, unrecoverable)
+
+        coVerify(exactly = 0) { failedMessageQueue.sendToRetryQueueIncoming(any(), any(), any()) }
+        coVerify { spyService.returnMessageError(any(), unrecoverable) }
+    }
+
+    @Test
     fun `sendToRetryInIfShouldBeRetried does not retry when ttl expired and returns MessageError`() = runBlocking {
         val receiverRecord = mockk<ReceiverRecord<String, ByteArray>>(relaxed = true)
         val headers = mockk<Headers>()

--- a/ebms-payload/src/main/kotlin/no/nav/emottak/payload/Processor.kt
+++ b/ebms-payload/src/main/kotlin/no/nav/emottak/payload/Processor.kt
@@ -36,9 +36,10 @@ class Processor(
     private val ninResolver: NinResolver = NinResolver()
 
     suspend fun loggMessageToJuridiskLogg(payloadRequest: PayloadRequest): String? {
-        log.info(payloadRequest.marker(), "Save message to juridisk logg")
+        log.debug(payloadRequest.marker(), "Save message to juridisk logg")
         try {
             return juridiskLogging.logge(payloadRequest).also {
+                log.info(payloadRequest.marker(), "Message saved to juridisk logg with id: $it")
                 eventRegistrationService.registerEvent(
                     EventType.MESSAGE_SAVED_IN_JURIDISK_LOGG,
                     payloadRequest,

--- a/ebms-payload/src/main/kotlin/no/nav/emottak/payload/Routes.kt
+++ b/ebms-payload/src/main/kotlin/no/nav/emottak/payload/Routes.kt
@@ -12,8 +12,6 @@ import io.ktor.server.routing.post
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
 import no.kith.xmlstds.msghead._2006_05_24.MsgHead
 import no.nav.emottak.message.model.Direction
-import no.nav.emottak.message.model.ErrorCode
-import no.nav.emottak.message.model.Feil
 import no.nav.emottak.message.model.Payload
 import no.nav.emottak.message.model.PayloadRequest
 import no.nav.emottak.message.model.PayloadResponse
@@ -108,7 +106,7 @@ private suspend fun createIncomingPayloadResponse(
         val errorPayload: Payload? = createNegativeAppRecOrErrorPayload(processConfig, request, readablePayload, e)
         PayloadResponse(
             processedPayload = errorPayload,
-            error = Feil(ErrorCode.UNKNOWN, e.localizedMessage, "Error"),
+            error = e.convertToFeil(),
             apprec = errorPayload != null
         )
     }

--- a/ebms-payload/src/main/kotlin/no/nav/emottak/payload/error/PayloadException.kt
+++ b/ebms-payload/src/main/kotlin/no/nav/emottak/payload/error/PayloadException.kt
@@ -22,7 +22,7 @@ fun Throwable.convertToFeil(): Feil = when (this) {
     is DecryptionException -> Feil(ErrorCode.SECURITY_FAILURE, localizedMessage, SeverityType.ERROR.value(), this.recoverable)
     is CompressionException -> Feil(ErrorCode.SECURITY_FAILURE, localizedMessage, SeverityType.ERROR.value(), this.recoverable)
     is DecompressionException -> Feil(ErrorCode.SECURITY_FAILURE, localizedMessage, SeverityType.ERROR.value(), this.recoverable)
-    is SignatureException -> Feil(ErrorCode.SECURITY_FAILURE, localizedMessage, SeverityType.ERROR.value(), false)
+    is SignatureException -> Feil(ErrorCode.SECURITY_FAILURE, localizedMessage, SeverityType.ERROR.value(), true)
     is CertificateException -> Feil(ErrorCode.SECURITY_FAILURE, localizedMessage, SeverityType.ERROR.value(), this.recoverable)
     else -> Feil(ErrorCode.UNKNOWN, this.localizedMessage, SeverityType.ERROR.value())
 }

--- a/ebms-payload/src/main/kotlin/no/nav/emottak/payload/error/PayloadException.kt
+++ b/ebms-payload/src/main/kotlin/no/nav/emottak/payload/error/PayloadException.kt
@@ -6,24 +6,24 @@ import no.nav.emottak.util.signatur.SignatureException
 import no.nav.emottak.utils.kafka.model.EventType
 import org.oasis_open.committees.ebxml_msg.schema.msg_header_2_0.SeverityType
 
-open class PayloadException(message: String?, cause: Throwable?) : Exception(message, cause)
+open class PayloadException(message: String?, cause: Throwable?, val recoverable: Boolean) : Exception(message, cause)
 
-open class CertificateException(message: String, cause: Exception? = null) : PayloadException(message, cause)
+open class CertificateException(message: String, cause: Exception? = null) : PayloadException(message, cause, true)
 class OCSPValidationFnrBlankError(message: String, cause: Exception? = null) : CertificateException(message, cause)
-class CompressionException(message: String, cause: Exception? = null) : PayloadException(message, cause)
-class DecompressionException(message: String, cause: Exception? = null) : PayloadException(message, cause)
-class DecryptionException(message: String, cause: Exception? = null) : PayloadException(message, cause)
-class EncryptionException(message: String, cause: Exception? = null) : PayloadException(message, cause)
-class JuridiskLoggException(message: String, cause: Exception? = null) : PayloadException(message, cause)
+class CompressionException(message: String, cause: Exception? = null) : PayloadException(message, cause, true)
+class DecompressionException(message: String, cause: Exception? = null) : PayloadException(message, cause, false)
+class DecryptionException(message: String, cause: Exception? = null) : PayloadException(message, cause, false)
+class EncryptionException(message: String, cause: Exception? = null) : PayloadException(message, cause, true)
+class JuridiskLoggException(message: String, cause: Exception? = null) : PayloadException(message, cause, true)
 
 fun Throwable.convertToFeil(): Feil = when (this) {
-    is JuridiskLoggException -> Feil(ErrorCode.DELIVERY_FAILURE, localizedMessage, SeverityType.ERROR.value())
-    is EncryptionException -> Feil(ErrorCode.SECURITY_FAILURE, localizedMessage, SeverityType.ERROR.value())
-    is DecryptionException -> Feil(ErrorCode.SECURITY_FAILURE, localizedMessage, SeverityType.ERROR.value())
-    is CompressionException -> Feil(ErrorCode.SECURITY_FAILURE, localizedMessage, SeverityType.ERROR.value())
-    is DecompressionException -> Feil(ErrorCode.SECURITY_FAILURE, localizedMessage, SeverityType.ERROR.value())
-    is SignatureException -> Feil(ErrorCode.SECURITY_FAILURE, localizedMessage, SeverityType.ERROR.value())
-    is CertificateException -> Feil(ErrorCode.SECURITY_FAILURE, localizedMessage, SeverityType.ERROR.value())
+    is JuridiskLoggException -> Feil(ErrorCode.DELIVERY_FAILURE, localizedMessage, SeverityType.ERROR.value(), this.recoverable)
+    is EncryptionException -> Feil(ErrorCode.SECURITY_FAILURE, localizedMessage, SeverityType.ERROR.value(), this.recoverable)
+    is DecryptionException -> Feil(ErrorCode.SECURITY_FAILURE, localizedMessage, SeverityType.ERROR.value(), this.recoverable)
+    is CompressionException -> Feil(ErrorCode.SECURITY_FAILURE, localizedMessage, SeverityType.ERROR.value(), this.recoverable)
+    is DecompressionException -> Feil(ErrorCode.SECURITY_FAILURE, localizedMessage, SeverityType.ERROR.value(), this.recoverable)
+    is SignatureException -> Feil(ErrorCode.SECURITY_FAILURE, localizedMessage, SeverityType.ERROR.value(), false)
+    is CertificateException -> Feil(ErrorCode.SECURITY_FAILURE, localizedMessage, SeverityType.ERROR.value(), this.recoverable)
     else -> Feil(ErrorCode.UNKNOWN, this.localizedMessage, SeverityType.ERROR.value())
 }
 

--- a/ebms-payload/src/main/kotlin/no/nav/emottak/payload/juridisklogg/JuridiskLoggService.kt
+++ b/ebms-payload/src/main/kotlin/no/nav/emottak/payload/juridisklogg/JuridiskLoggService.kt
@@ -60,9 +60,9 @@ class JuridiskLoggService() {
 
                 if (httpResponse.status == HttpStatusCode.OK) {
                     juridiskLoggRecordId = httpResponse.body<JuridiskLoggResponse>().id
-                    log.info(payloadRequest.marker(), "Message saved to juridisk logg")
+                    log.debug(payloadRequest.marker(), "Message saved to juridisk logg")
                 } else {
-                    log.info(payloadRequest.marker(), "Failed to save message to juridisk logg: $httpResponse")
+                    log.warn(payloadRequest.marker(), "Failed to save message to juridisk logg: $httpResponse")
                 }
             } catch (e: Exception) {
                 log.error(payloadRequest.marker(), "Exception occurred during sending message to juridisk logg: ${e.message}", e)

--- a/ebms-provider/src/main/kotlin/no/nav/emottak/ebms/processing/ProcessingService.kt
+++ b/ebms-provider/src/main/kotlin/no/nav/emottak/ebms/processing/ProcessingService.kt
@@ -2,13 +2,13 @@ package no.nav.emottak.ebms.processing
 
 import io.ktor.client.call.body
 import io.ktor.client.plugins.ClientRequestException
-import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import no.nav.emottak.ebms.PayloadProcessingClient
 import no.nav.emottak.ebms.logger
 import no.nav.emottak.message.exception.EbmsException
 import no.nav.emottak.message.model.Direction
+import no.nav.emottak.message.model.ErrorCode
 import no.nav.emottak.message.model.Payload
 import no.nav.emottak.message.model.PayloadMessage
 import no.nav.emottak.message.model.PayloadProcessing
@@ -49,23 +49,30 @@ class ProcessingService(private val httpClient: PayloadProcessingClient) {
                 "Processing failed: ${clientRequestException.message}",
                 clientRequestException
             )
-            val payloadError = runCatching { clientRequestException.response.body<PayloadResponse>().error }.getOrNull()
-            val errorMsg = "Processing has failed${payloadError?.let { ": ${it.descriptionText} [${it.code.value}]" } ?: ""}"
-            when (clientRequestException.response.status) {
-                HttpStatusCode.BadRequest -> {
-                    return Pair(
-                        payloadMessage.convertToErrorActionMessage(
-                            clientRequestException.retrieveReturnableApprecResponse(direction, errorMsg).processedPayload!!,
-                            payloadProcessing.processConfig.errorAction!!
-                        ),
-                        Direction.OUT
-                    )
-                }
-
-                else -> throw EbmsException(errorMsg, exception = clientRequestException)
+            val payloadErrorMessage = runCatching { clientRequestException.response.body<PayloadResponse>() }.getOrNull()
+            val payloadError = payloadErrorMessage?.error
+            val errorMsg = payloadError?.let { "${it.descriptionText} [${it.code.value}]" } ?: "Processing has failed"
+            val errorCode = payloadError?.code ?: ErrorCode.UNKNOWN
+            if (payloadErrorMessage?.apprec == true) {
+                return Pair(
+                    payloadMessage.convertToErrorActionMessage(
+                        clientRequestException.retrieveReturnableApprecResponse(
+                            direction,
+                            errorMsg
+                        ).processedPayload!!,
+                        payloadProcessing.processConfig.errorAction!!
+                    ),
+                    Direction.OUT
+                )
+            } else {
+                throw EbmsException(
+                    message = errorMsg,
+                    errorCode = errorCode,
+                    exception = clientRequestException
+                )
             }
         } catch (exception: Exception) {
-            throw EbmsException("Processing has failed", exception = exception)
+            throw EbmsException("An unexpected error occurred", exception = exception)
         }
     }
 

--- a/ebms-provider/src/main/kotlin/no/nav/emottak/ebms/processing/ProcessingService.kt
+++ b/ebms-provider/src/main/kotlin/no/nav/emottak/ebms/processing/ProcessingService.kt
@@ -58,14 +58,19 @@ class ProcessingService(private val httpClient: PayloadProcessingClient) {
                     payloadMessage.convertToErrorActionMessage(
                         clientRequestException.retrieveReturnableApprecResponse(
                             direction,
-                            errorMsg
+                            payloadError?.let { "${it.descriptionText} [${it.code.value}]" } ?: "Processing has failed"
                         ).processedPayload!!,
                         payloadProcessing.processConfig.errorAction!!
                     ),
                     Direction.OUT
                 )
             } else {
-                throw EbmsException(
+                throw payloadError?.let {
+                    EbmsException(
+                        feil = listOf(payloadError),
+                        exception = clientRequestException
+                    )
+                } ?: EbmsException(
                     message = errorMsg,
                     errorCode = errorCode,
                     exception = clientRequestException

--- a/ebms-provider/src/test/kotlin/no/nav/emottak/ebms/EbmsRouteSyncIT.kt
+++ b/ebms-provider/src/test/kotlin/no/nav/emottak/ebms/EbmsRouteSyncIT.kt
@@ -8,6 +8,7 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.install
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.server.response.respond
+import io.ktor.server.response.respondText
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.post
 import io.ktor.server.routing.routing
@@ -366,7 +367,92 @@ class EbmsRouteSyncIT {
         assertEquals(HttpStatusCode.OK, response.status)
         assertEquals(1, externalServiceCalledCount, "Forventet kall til externalService.")
         with(getEnvelope(response).assertErrorAndGet().error.first()) {
-            assertEquals("Processing has failed: Noe gikk galt i ebms-payload [${ErrorCode.UNKNOWN.value}]", this.description!!.value)
+            assertEquals("Noe gikk galt i ebms-payload [${ErrorCode.UNKNOWN.value}]", this.description!!.value)
+        }
+    }
+
+    @Test
+    fun `Feilkode fra EBMS-PAYLOAD bevares når apprec er false`() = testSyncApp {
+        val errorMsg = "Sertifikat er utløpt"
+        var externalServiceCalledCount = 0
+        externalServices {
+            hosts(getEnvVar("PAYLOAD_PROCESSOR_URL", "http://ebms-payload")) {
+                this.install(ContentNegotiation) {
+                    jsonLenient()
+                }
+                routing {
+                    post("payload") {
+                        externalServiceCalledCount++
+                        call.respond(
+                            status = HttpStatusCode.BadRequest,
+                            message = PayloadResponse(
+                                error = Feil(ErrorCode.SECURITY_FAILURE, errorMsg, "Error"),
+                                apprec = false
+                            )
+                        )
+                    }
+                }
+            }
+        }
+        val multipart = TestData.HarBorgerEgenandel.harBorgerEgenandelFritakRequestWithFormItem
+        val response = client.post(SYNC_PATH, multipart.asHttpRequest())
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertEquals(1, externalServiceCalledCount, "Forventet kall til externalService.")
+        with(getEnvelope(response).assertErrorAndGet().error.first()) {
+            assertEquals("$errorMsg [${ErrorCode.SECURITY_FAILURE.value}]", this.description!!.value)
+            assertEquals(ErrorCode.SECURITY_FAILURE.value, this.errorCode)
+        }
+    }
+
+    @Test
+    fun `Uleselig svar fra EBMS-PAYLOAD gir fallback-feilmelding med Unknown feilkode`() = testSyncApp {
+        var externalServiceCalledCount = 0
+        externalServices {
+            hosts(getEnvVar("PAYLOAD_PROCESSOR_URL", "http://ebms-payload")) {
+                routing {
+                    post("payload") {
+                        externalServiceCalledCount++
+                        call.respondText(
+                            text = "Forespørselen kunne ikke behandles",
+                            status = HttpStatusCode.BadRequest
+                        )
+                    }
+                }
+            }
+        }
+        val multipart = TestData.HarBorgerEgenandel.harBorgerEgenandelFritakRequestWithFormItem
+        val response = client.post(SYNC_PATH, multipart.asHttpRequest())
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertEquals(1, externalServiceCalledCount, "Forventet kall til externalService.")
+        with(getEnvelope(response).assertErrorAndGet().error.first()) {
+            assertEquals("Processing has failed", this.description!!.value)
+            assertEquals(ErrorCode.UNKNOWN.value, this.errorCode)
+        }
+    }
+
+    @Test
+    fun `5xx svar fra EBMS-PAYLOAD ignorerer responsbody og gir fallback-feilmelding`() = testSyncApp {
+        var externalServiceCalledCount = 0
+        externalServices {
+            hosts(getEnvVar("PAYLOAD_PROCESSOR_URL", "http://ebms-payload")) {
+                routing {
+                    post("payload") {
+                        externalServiceCalledCount++
+                        call.respondText(
+                            text = "Internal server error",
+                            status = HttpStatusCode.InternalServerError
+                        )
+                    }
+                }
+            }
+        }
+        val multipart = TestData.HarBorgerEgenandel.harBorgerEgenandelFritakRequestWithFormItem
+        val response = client.post(SYNC_PATH, multipart.asHttpRequest())
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertEquals(1, externalServiceCalledCount, "Forventet kall til externalService.")
+        with(getEnvelope(response).assertErrorAndGet().error.first()) {
+            assertEquals("An unexpected error occurred", this.description!!.value)
+            assertEquals(ErrorCode.UNKNOWN.value, this.errorCode)
         }
     }
 

--- a/ebms-provider/src/test/kotlin/no/nav/emottak/ebms/EbmsRouteSyncIT.kt
+++ b/ebms-provider/src/test/kotlin/no/nav/emottak/ebms/EbmsRouteSyncIT.kt
@@ -367,7 +367,7 @@ class EbmsRouteSyncIT {
         assertEquals(HttpStatusCode.OK, response.status)
         assertEquals(1, externalServiceCalledCount, "Forventet kall til externalService.")
         with(getEnvelope(response).assertErrorAndGet().error.first()) {
-            assertEquals("Noe gikk galt i ebms-payload [${ErrorCode.UNKNOWN.value}]", this.description!!.value)
+            assertEquals("Noe gikk galt i ebms-payload", this.description!!.value)
         }
     }
 
@@ -399,7 +399,7 @@ class EbmsRouteSyncIT {
         assertEquals(HttpStatusCode.OK, response.status)
         assertEquals(1, externalServiceCalledCount, "Forventet kall til externalService.")
         with(getEnvelope(response).assertErrorAndGet().error.first()) {
-            assertEquals("$errorMsg [${ErrorCode.SECURITY_FAILURE.value}]", this.description!!.value)
+            assertEquals(errorMsg, this.description!!.value)
             assertEquals(ErrorCode.SECURITY_FAILURE.value, this.errorCode)
         }
     }

--- a/ebxml-processing-model/src/main/kotlin/no/nav/emottak/message/exception/EbmsException.kt
+++ b/ebxml-processing-model/src/main/kotlin/no/nav/emottak/message/exception/EbmsException.kt
@@ -13,8 +13,9 @@ open class EbmsException(
         message: String,
         errorCode: ErrorCode = ErrorCode.UNKNOWN,
         severity: String = SeverityType.ERROR.value()!!,
+        recoverable: Boolean = true,
         exception: Throwable? = null
-    ) : this(listOf(Feil(errorCode, message, severity)), exception)
+    ) : this(listOf(Feil(errorCode, message, severity, recoverable)), exception)
 
     companion object {
         fun concatFeilmessage(feil: List<Feil>) =
@@ -22,4 +23,6 @@ open class EbmsException(
                 it.descriptionText
             }
     }
+
+    fun isRecoverable() = feil.all { it.recoverable }
 }

--- a/ebxml-processing-model/src/main/kotlin/no/nav/emottak/message/model/Payload.kt
+++ b/ebxml-processing-model/src/main/kotlin/no/nav/emottak/message/model/Payload.kt
@@ -41,7 +41,8 @@ data class PayloadResponse(
 data class Feil(
     val code: ErrorCode,
     val descriptionText: String,
-    val severity: String? = null
+    val severity: String? = null,
+    val recoverable: Boolean = true
 ) {
 
     fun asEbxmlError(location: String? = null): Error {


### PR DESCRIPTION
- ErrorCode fra feil ebms-payload bevares. Istedenfor å alltid returnere UNKNOWN-feilkode ved feil i payload-prosessering, hentes nå faktisk feilkode
- Skille mellom feil som kan fikses ved rekjøring og de som ikke kan det. Feil og EbmsException er utvidet med et recoverable-flagg. PayloadException-subklassene er merket med om de er recoverable eller ikke.
- Retry-logikken håndterer feil som ikke er recoverable. RetryService har fått en ny NO_RETRY-beslutning som skipper all retry. For innkommende meldinger sendes en MessageError tilbake til avsender.