### PR TITLE
Endepunkt for å hente utestående meldinger vi mangler ack for

### DIFF
--- a/ebms-async/build.gradle.kts
+++ b/ebms-async/build.gradle.kts
@@ -45,6 +45,7 @@ dependencies {
     implementation(libs.arrow.resilience)
     implementation(libs.arrow.suspendapp)
     implementation(libs.arrow.suspendapp.ktor)
+    implementation(libs.ktor.server.html.builder)
     implementation(libs.ktor.server.call.logging.jvm)
     implementation(libs.ktor.server.core)
     implementation(libs.ktor.server.core.jvm)

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/App.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/App.kt
@@ -404,6 +404,8 @@ fun Application.ebmsProviderModule(
         pauseRetries(pauseRetryErrorsTimerFlag)
         resumeRetries(pauseRetryErrorsTimerFlag)
         unacknowledge(messagePendingAckRepository)
+        getMessagesPendingAck(messagePendingAckRepository)
+        getMessagesPendingAckHtml(messagePendingAckRepository)
         authenticate(AZURE_AD_AUTH) {
             getPayloads(payloadRepository, eventRegistrationService)
         }

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/MessagePendingAckHtmlView.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/MessagePendingAckHtmlView.kt
@@ -1,0 +1,77 @@
+package no.nav.emottak.ebms.async
+
+import kotlinx.html.HTML
+import kotlinx.html.body
+import kotlinx.html.h1
+import kotlinx.html.head
+import kotlinx.html.style
+import kotlinx.html.table
+import kotlinx.html.tbody
+import kotlinx.html.td
+import kotlinx.html.th
+import kotlinx.html.thead
+import kotlinx.html.title
+import kotlinx.html.tr
+import kotlinx.html.unsafe
+import no.nav.emottak.ebms.async.persistence.repository.MessagePendingAckSummary
+
+fun HTML.renderMessagesPendingAck(messages: List<MessagePendingAckSummary>) {
+    head {
+        title { +"Messages Pending Ack" }
+        style {
+            unsafe {
+                raw(
+                    """
+                    body { font-family: sans-serif; padding: 1rem; }
+                    h1 { font-size: 1.25rem; margin-bottom: 1rem; }
+                    table { border-collapse: collapse; width: 100%; font-size: 0.875rem; }
+                    th, td { border: 1px solid #ccc; padding: 0.4rem 0.6rem; text-align: left; }
+                    th { background: #f0f0f0; font-weight: bold; }
+                    tr:nth-child(even) { background: #fafafa; }
+                    """.trimIndent()
+                )
+            }
+        }
+    }
+    body {
+        h1 { +"Messages Pending Ack (${messages.size})" }
+        table {
+            thead {
+                tr {
+                    th { +"Request ID" }
+                    th { +"Conversation ID" }
+                    th { +"Message ID" }
+                    th { +"Ref To Message ID" }
+                    th { +"CPA ID" }
+                    th { +"Service" }
+                    th { +"Action" }
+                    th { +"Receiver HER ID" }
+                    th { +"Receiver Orgnummer" }
+                    th { +"Email List" }
+                    th { +"First Sent" }
+                    th { +"Last Sent" }
+                    th { +"Resent Count" }
+                }
+            }
+            tbody {
+                messages.forEach { msg ->
+                    tr {
+                        td { +msg.requestId }
+                        td { +msg.conversationId }
+                        td { +msg.messageId }
+                        td { +(msg.refToMessageId ?: "") }
+                        td { +msg.cpaId }
+                        td { +msg.service }
+                        td { +msg.action }
+                        td { +(msg.receiverHerId ?: "") }
+                        td { +(msg.receiverOrgnummer ?: "") }
+                        td { +msg.emailAddressList.joinToString(", ") }
+                        td { +msg.firstSent }
+                        td { +msg.lastSent }
+                        td { +msg.resentCount.toString() }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/Routes.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/Routes.kt
@@ -1,6 +1,7 @@
 package no.nav.emottak.ebms.async
 
 import io.ktor.http.HttpStatusCode
+import io.ktor.server.html.respondHtml
 import io.ktor.server.response.respond
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.Route
@@ -92,6 +93,20 @@ fun Route.getPayloads(
         )
     }
     return@get
+}
+
+fun Route.getMessagesPendingAck(
+    messagePendingAckRepository: MessagePendingAckRepository
+): Route = get("/api/messages/pending-ack") {
+    call.respond(HttpStatusCode.OK, messagePendingAckRepository.findAllWithoutAck())
+}
+
+fun Route.getMessagesPendingAckHtml(
+    messagePendingAckRepository: MessagePendingAckRepository
+): Route = get("/api/messages/pending-ack/view") {
+    call.respondHtml(HttpStatusCode.OK) {
+        renderMessagesPendingAck(messagePendingAckRepository.findAllWithoutAck())
+    }
 }
 
 fun Route.unacknowledge(

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/Routes.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/Routes.kt
@@ -21,6 +21,10 @@ import no.nav.emottak.ebms.async.processing.RetryService
 import no.nav.emottak.ebms.async.util.EventRegistrationService
 import no.nav.emottak.utils.kafka.model.EventType
 import no.nav.emottak.utils.serialization.toEventDataJson
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
+import java.time.temporal.ChronoUnit
 import kotlin.uuid.Uuid
 
 private const val REFERENCE_ID = "referenceId"
@@ -98,16 +102,25 @@ fun Route.getPayloads(
 fun Route.getMessagesPendingAck(
     messagePendingAckRepository: MessagePendingAckRepository
 ): Route = get("/api/messages/pending-ack") {
-    call.respond(HttpStatusCode.OK, messagePendingAckRepository.findAllWithoutAck())
+    val since = parseSinceParameter(call.request.queryParameters["since"])
+    call.respond(HttpStatusCode.OK, messagePendingAckRepository.findAllWithoutAck(since))
 }
 
 fun Route.getMessagesPendingAckHtml(
     messagePendingAckRepository: MessagePendingAckRepository
 ): Route = get("/api/messages/pending-ack/view") {
+    val since = parseSinceParameter(call.request.queryParameters["since"])
     call.respondHtml(HttpStatusCode.OK) {
-        renderMessagesPendingAck(messagePendingAckRepository.findAllWithoutAck())
+        renderMessagesPendingAck(messagePendingAckRepository.findAllWithoutAck(since))
     }
 }
+
+private fun parseSinceParameter(value: String?): Instant =
+    if (value != null) {
+        LocalDate.parse(value).atStartOfDay().toInstant(ZoneOffset.UTC)
+    } else {
+        Instant.now().minus(14, ChronoUnit.DAYS)
+    }
 
 fun Route.unacknowledge(
     messagePendingAckRepository: MessagePendingAckRepository

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/persistence/repository/MessagePendingAckRepository.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/persistence/repository/MessagePendingAckRepository.kt
@@ -5,8 +5,10 @@ import no.nav.emottak.ebms.async.persistence.Database
 import no.nav.emottak.ebms.async.persistence.table.MessagePendingAckTable
 import no.nav.emottak.message.model.EmailAddress
 import no.nav.emottak.message.xml.xmlMarshaller
+import org.jetbrains.exposed.v1.core.SortOrder
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.greaterEq
 import org.jetbrains.exposed.v1.core.less
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.select
@@ -145,7 +147,7 @@ class MessagePendingAckRepository(
         }
     }
 
-    fun findAllWithoutAck(): List<MessagePendingAckSummary> {
+    fun findAllWithoutAck(since: Instant = Instant.now().minus(14, java.time.temporal.ChronoUnit.DAYS)): List<MessagePendingAckSummary> {
         return transaction(database.db) {
             MessagePendingAckTable
                 .select(
@@ -157,7 +159,11 @@ class MessagePendingAckRepository(
                     MessagePendingAckTable.lastSent,
                     MessagePendingAckTable.resentCount
                 )
-                .where { MessagePendingAckTable.ackReceived.eq(false) }
+                .where {
+                    MessagePendingAckTable.ackReceived.eq(false)
+                        .and(MessagePendingAckTable.firstSent.greaterEq(since))
+                }
+                .orderBy(MessagePendingAckTable.firstSent, SortOrder.DESC)
                 .map {
                     val header = xmlMarshaller.unmarshal(it[MessagePendingAckTable.messageHeader], MessageHeader::class.java)
                     MessagePendingAckSummary(

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/persistence/repository/MessagePendingAckRepository.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/persistence/repository/MessagePendingAckRepository.kt
@@ -1,5 +1,6 @@
 package no.nav.emottak.ebms.async.persistence.repository
 
+import kotlinx.serialization.Serializable
 import no.nav.emottak.ebms.async.persistence.Database
 import no.nav.emottak.ebms.async.persistence.table.MessagePendingAckTable
 import no.nav.emottak.message.model.EmailAddress
@@ -35,6 +36,23 @@ data class MessagePendingAck(
     val firstSent: Instant = Instant.now(),
     val lastSent: Instant = Instant.now(),
     val resentCount: Int = 0
+)
+
+@Serializable
+data class MessagePendingAckSummary(
+    val messageId: String,
+    val requestId: String,
+    val cpaId: String,
+    val conversationId: String,
+    val refToMessageId: String?,
+    val service: String,
+    val action: String,
+    val receiverHerId: String?,
+    val receiverOrgnummer: String?,
+    val emailAddressList: List<String>,
+    val firstSent: String,
+    val lastSent: String,
+    val resentCount: Int
 )
 
 private val log = LoggerFactory.getLogger(MessagePendingAckRepository::class.java)
@@ -124,6 +142,40 @@ class MessagePendingAckRepository(
                     it[ackReceived] = false
                     it[resentCount] = 0
                 } > 0
+        }
+    }
+
+    fun findAllWithoutAck(): List<MessagePendingAckSummary> {
+        return transaction(database.db) {
+            MessagePendingAckTable
+                .select(
+                    MessagePendingAckTable.messageId,
+                    MessagePendingAckTable.requestId,
+                    MessagePendingAckTable.messageHeader,
+                    MessagePendingAckTable.emailAddressList,
+                    MessagePendingAckTable.firstSent,
+                    MessagePendingAckTable.lastSent,
+                    MessagePendingAckTable.resentCount
+                )
+                .where { MessagePendingAckTable.ackReceived.eq(false) }
+                .map {
+                    val header = xmlMarshaller.unmarshal(it[MessagePendingAckTable.messageHeader], MessageHeader::class.java)
+                    MessagePendingAckSummary(
+                        messageId = it[MessagePendingAckTable.messageId].toString(),
+                        requestId = it[MessagePendingAckTable.requestId].toString(),
+                        cpaId = header.cpaId ?: "",
+                        conversationId = header.conversationId ?: "",
+                        refToMessageId = header.messageData.refToMessageId,
+                        service = header.service.value ?: "",
+                        action = header.action ?: "",
+                        receiverHerId = header.to.partyId.firstOrNull { it.type == "HER" }?.value,
+                        receiverOrgnummer = header.to.partyId.firstOrNull { it.type == "orgnummer" }?.value,
+                        emailAddressList = it[MessagePendingAckTable.emailAddressList].split(","),
+                        firstSent = it[MessagePendingAckTable.firstSent].toString(),
+                        lastSent = it[MessagePendingAckTable.lastSent].toString(),
+                        resentCount = it[MessagePendingAckTable.resentCount]
+                    )
+                }
         }
     }
 

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/persistence/repository/MessagePendingAckRepository.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/persistence/repository/MessagePendingAckRepository.kt
@@ -164,6 +164,7 @@ class MessagePendingAckRepository(
                         .and(MessagePendingAckTable.firstSent.greaterEq(since))
                 }
                 .orderBy(MessagePendingAckTable.firstSent, SortOrder.DESC)
+                .filter { it[MessagePendingAckTable.firstSent] < Instant.now().minus(5, java.time.temporal.ChronoUnit.MINUTES) }
                 .map {
                     val header = xmlMarshaller.unmarshal(it[MessagePendingAckTable.messageHeader], MessageHeader::class.java)
                     MessagePendingAckSummary(

--- a/ebms-async/src/main/resources/db/migration/V11__index_message_pending_ack_not_acked.sql
+++ b/ebms-async/src/main/resources/db/migration/V11__index_message_pending_ack_not_acked.sql
@@ -1,0 +1,3 @@
+CREATE INDEX idx_message_pending_ack_not_acked
+    ON message_pending_ack (message_id)
+    WHERE ack_received = false;


### PR DESCRIPTION
Endepunkt som henter meldinger fra `MessagePendingAckRepository` der `ack_received = false`. Kan brukes fra for eksempel monitor.

`GET /api/messages/pending-ack` som returnerer en liste over meldinger i json.