### PR TITLE
Periodisk jobb for sletting av payloads

### DIFF
--- a/ebms-async/build.gradle.kts
+++ b/ebms-async/build.gradle.kts
@@ -78,13 +78,11 @@ dependencies {
     implementation("no.nav:vault-jdbc:1.3.10")
 
     testImplementation(project(":cpa-repo"))
-    testImplementation(project(":ebms-provider"))
     testImplementation(testLibs.mock.oauth2.server)
     testImplementation(testLibs.ktor.server.test.host)
     testImplementation(testLibs.junit.jupiter.api)
     testImplementation(testLibs.mockk.jvm)
     testImplementation(testLibs.mockk.dsl.jvm)
-    testImplementation(libs.apache.santuario)
     testImplementation(testLibs.testcontainers.postgresql)
     testImplementation(testLibs.testcontainers.kafka)
     testRuntimeOnly(testLibs.junit.jupiter.engine)

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/App.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/App.kt
@@ -50,6 +50,7 @@ import no.nav.emottak.ebms.async.processing.SignalMessageService
 import no.nav.emottak.ebms.async.processing.sendSignalResponseToTopic
 import no.nav.emottak.ebms.async.util.EventRegistrationService
 import no.nav.emottak.ebms.async.util.EventRegistrationServiceImpl
+import no.nav.emottak.ebms.async.util.readableInterval
 import no.nav.emottak.ebms.defaultHttpClient
 import no.nav.emottak.ebms.processing.ProcessingService
 import no.nav.emottak.ebms.registerHealthEndpoints
@@ -66,7 +67,11 @@ import no.nav.emottak.utils.kafka.client.EventPublisherClient
 import no.nav.emottak.utils.kafka.service.EventLoggingService
 import no.nav.emottak.utils.serialization.LENIENT_JSON_PARSER
 import org.slf4j.LoggerFactory
+import java.time.LocalDateTime
+import java.time.LocalTime
 import kotlin.concurrent.timer
+import kotlin.time.Duration
+import kotlin.time.toKotlinDuration
 
 val log = LoggerFactory.getLogger("no.nav.emottak.ebms.async.App")
 
@@ -180,6 +185,10 @@ fun main() = SuspendApp {
                 messagePendingAckRepository = messagePendingAckRepository,
                 payloadMessageForwardingService = payloadMessageForwardingService,
                 meterRegistry = appMicrometerRegistry
+            )
+            launchCleanupPayloadsTask(
+                config = config,
+                payloadRepository = payloadRepository
             )
 
             server(
@@ -344,6 +353,45 @@ fun CoroutineScope.launchErrorRetryTaskOutgoing(
             }
         }
     }
+}
+
+fun CoroutineScope.launchCleanupPayloadsTask(
+    config: Config,
+    payloadRepository: PayloadRepository
+) {
+    if (!config.cleanupPayloadsJob.enabled) return
+
+    val initialDelay = durationUntil(config.cleanupPayloadsJob.startAtTime.value)
+    val readableInterval = config.cleanupPayloadsJob.fixedInterval.readableInterval()
+    log.info("Delaying initial payload cleanup by ${initialDelay.readableInterval()}, running every $readableInterval after that")
+    timer(
+        name = "Cleanup Payloads Timer Job",
+        initialDelay = initialDelay.inWholeMilliseconds,
+        period = config.cleanupPayloadsJob.fixedInterval.inWholeMilliseconds,
+        daemon = true
+    ) {
+        launch(Dispatchers.IO) {
+            log.info("=== CleanupPayloadsJob starting...")
+            try {
+                val deleted = payloadRepository.cleanupOldPayloads(
+                    config.cleanupPayloadsJob.keepPayloadsDays.value,
+                    config.cleanupPayloadsJob.batchSize.value.toInt()
+                )
+                log.info("CleanupPayloadsJob deleted $deleted payload(s) older than ${config.cleanupPayloadsJob.keepPayloadsDays.value} days")
+            } catch (e: Exception) {
+                log.error("CleanupPayloadsJob failed", e)
+            }
+        }
+    }
+}
+
+/** Time remaining until the next occurrence of [runAtTime], today if not yet passed, otherwise tomorrow. */
+private fun durationUntil(runAtTime: LocalTime): Duration {
+    val now = LocalDateTime.now()
+    val nextRun = now.toLocalDate().atTime(runAtTime).let { todayRun ->
+        if (now.isBefore(todayRun)) todayRun else todayRun.plusDays(1)
+    }
+    return java.time.Duration.between(now, nextRun).toKotlinDuration()
 }
 
 fun CoroutineScope.launchMesssageResendTask(

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/App.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/App.kt
@@ -361,7 +361,7 @@ fun CoroutineScope.launchCleanupPayloadsTask(
 ) {
     if (!config.cleanupPayloadsJob.enabled) return
 
-    val initialDelay = durationUntil(config.cleanupPayloadsJob.startAtTime.value)
+    val initialDelay = config.cleanupPayloadsJob.startAtTime.value.durationUntil()
     val readableInterval = config.cleanupPayloadsJob.fixedInterval.readableInterval()
     log.info("Delaying initial payload cleanup by ${initialDelay.readableInterval()}, running every $readableInterval after that")
     timer(
@@ -385,10 +385,9 @@ fun CoroutineScope.launchCleanupPayloadsTask(
     }
 }
 
-/** Time remaining until the next occurrence of [runAtTime], today if not yet passed, otherwise tomorrow. */
-private fun durationUntil(runAtTime: LocalTime): Duration {
-    val now = LocalDateTime.now()
-    val nextRun = now.toLocalDate().atTime(runAtTime).let { todayRun ->
+/** Returnerer Duration (gjenstående tid) til neste gang klokka er det samme som LocalTime-objektet. */
+internal fun LocalTime.durationUntil(now: LocalDateTime = LocalDateTime.now()): Duration {
+    val nextRun = now.toLocalDate().atTime(this).let { todayRun ->
         if (now.isBefore(todayRun)) todayRun else todayRun.plusDays(1)
     }
     return java.time.Duration.between(now, nextRun).toKotlinDuration()

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/configuration/Config.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/configuration/Config.kt
@@ -13,6 +13,7 @@ import org.apache.kafka.common.config.SslConfigs.SSL_KEYSTORE_TYPE_CONFIG
 import org.apache.kafka.common.config.SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG
 import org.apache.kafka.common.config.SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG
 import org.apache.kafka.common.config.SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG
+import java.time.LocalTime
 import kotlin.time.Duration
 
 data class Config(
@@ -29,7 +30,8 @@ data class Config(
     val signering: List<KeyStoreConfiguration>,
     val errorRetryPolicyIncoming: ErrorRetryPolicy,
     val errorRetryPolicyOutgoing: ErrorRetryPolicy,
-    val messageResendPolicy: MessageResendPolicy
+    val messageResendPolicy: MessageResendPolicy,
+    val cleanupPayloadsJob: CleanupPayloadsJob
 )
 
 data class MessageResendPolicy(
@@ -69,6 +71,23 @@ data class ErrorRetryPolicy(
         return retryIntervals.size
     }
 }
+
+data class CleanupPayloadsJob(
+    val enabled: Boolean,
+    val fixedInterval: Duration,
+    val startAtTime: StartAtTime,
+    val keepPayloadsDays: KeepDays,
+    val batchSize: BatchSize
+)
+
+@JvmInline
+value class StartAtTime(val value: LocalTime)
+
+@JvmInline
+value class KeepDays(val value: Int)
+
+@JvmInline
+value class BatchSize(val value: Long)
 
 fun Kafka.toProperties() =
     toProperties()

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/persistence/repository/PayloadRepository.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/persistence/repository/PayloadRepository.kt
@@ -1,5 +1,7 @@
 package no.nav.emottak.ebms.async.persistence.repository
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.asExecutor
 import no.nav.emottak.ebms.async.persistence.Database
 import no.nav.emottak.ebms.async.persistence.table.PayloadTable
 import no.nav.emottak.ebms.async.persistence.table.PayloadTable.contentId
@@ -40,6 +42,24 @@ class PayloadRepository(private val database: Database) {
                         it[PayloadTable.content]
                     )
                 }
+        }
+    }
+
+    /**
+     * Deletes payloads older than [keepDays], in batches of [batchSize], until no more
+     * matching rows remain. Returns the total number of deleted payloads.
+     */
+    fun cleanupOldPayloads(keepDays: Int, batchSize: Int): Long {
+        database.dataSource.connection.use { connection ->
+            connection.autoCommit = true
+            connection.setNetworkTimeout(Dispatchers.IO.asExecutor(), 0)
+            connection.prepareCall("CALL delete_old_payloads(?, ?, ?)").use { stmt ->
+                stmt.setInt(1, keepDays)
+                stmt.setInt(2, batchSize)
+                stmt.registerOutParameter(3, java.sql.Types.BIGINT)
+                stmt.executeUpdate()
+                return stmt.getLong(3)
+            }
         }
     }
 }

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/util/EbmsUtil.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/util/EbmsUtil.kt
@@ -1,8 +1,19 @@
 package no.nav.emottak.ebms.async.util
 
 import no.nav.emottak.utils.common.model.PartyId
+import kotlin.time.Duration
 
 fun List<PartyId>.getPreferredPartyId(): PartyId = this.firstOrNull { it.type == "HER" }
     ?: this.firstOrNull { it.type == "orgnummer" }
     ?: this.firstOrNull { it.type == "ENH" }
     ?: this.first()
+
+internal fun Duration.readableInterval(): String {
+    this.toComponents { days, hours, minutes, seconds, nanoseconds ->
+        var readable = ""
+        if (days > 0) readable = "$days days"
+        if (hours > 0) readable = if (readable != "") "$readable, $hours hours" else "$hours hours"
+        if (minutes > 0) readable = if (readable != "") "$readable, $minutes minutes" else "$minutes minutes"
+        return readable
+    }
+}

--- a/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/util/EbmsUtil.kt
+++ b/ebms-async/src/main/kotlin/no/nav/emottak/ebms/async/util/EbmsUtil.kt
@@ -8,12 +8,14 @@ fun List<PartyId>.getPreferredPartyId(): PartyId = this.firstOrNull { it.type ==
     ?: this.firstOrNull { it.type == "ENH" }
     ?: this.first()
 
+/** Lesbar presentasjon av en Duration, slik som "1 day, 3 hours, 30 minutes". */
 internal fun Duration.readableInterval(): String {
     this.toComponents { days, hours, minutes, seconds, nanoseconds ->
         var readable = ""
         if (days > 0) readable = "$days days"
         if (hours > 0) readable = if (readable != "") "$readable, $hours hours" else "$hours hours"
         if (minutes > 0) readable = if (readable != "") "$readable, $minutes minutes" else "$minutes minutes"
+        if (readable == "") readable = "$seconds seconds"
         return readable
     }
 }

--- a/ebms-async/src/main/resources/application.conf
+++ b/ebms-async/src/main/resources/application.conf
@@ -29,27 +29,34 @@ kafkaErrorQueueOut {
 }
 
 errorRetryPolicyIncoming {
-    startupDelay = "${SCHEDULED_PROCESS_STARTDELAY:-5m}"
-    processInterval = "${RETRY_PROCESS_INTERVAL:-5m}"
-    maxMessagesToProcess = "${RETRY_PROCESS_MAX_MESSAGES:-50}"
-    retryIntervals = "${RETRY_INTERVALS:-5m,15m,1h,24h}"
-    retriesPerInterval = "${RETRY_INTERVALS_NUMBERS:-3,3,23}"
-    maxRetries = "${RETRY_IN_MAX_TIMES:-32}"
+  startupDelay = "${SCHEDULED_PROCESS_STARTDELAY:-5m}"
+  processInterval = "${RETRY_PROCESS_INTERVAL:-5m}"
+  maxMessagesToProcess = "${RETRY_PROCESS_MAX_MESSAGES:-50}"
+  retryIntervals = "${RETRY_INTERVALS:-5m,15m,1h,24h}"
+  retriesPerInterval = "${RETRY_INTERVALS_NUMBERS:-3,3,23}"
+  maxRetries = "${RETRY_IN_MAX_TIMES:-32}"
 }
 
 errorRetryPolicyOutgoing {
-    startupDelay = "${SCHEDULED_PROCESS_STARTDELAY:-5m}"
-    processInterval = "${RETRY_PROCESS_INTERVAL:-5m}"
-    maxMessagesToProcess = "${RETRY_PROCESS_MAX_MESSAGES:-50}"
-    retryIntervals = "${RETRY_INTERVALS:-5m,15m,1h,24h}"
-    retriesPerInterval = "${RETRY_INTERVALS_NUMBERS:-3,3,23}"
-    maxRetries = "${RETRY_OUT_MAX_TIMES:-32}"
+  startupDelay = "${SCHEDULED_PROCESS_STARTDELAY:-5m}"
+  processInterval = "${RETRY_PROCESS_INTERVAL:-5m}"
+  maxMessagesToProcess = "${RETRY_PROCESS_MAX_MESSAGES:-50}"
+  retryIntervals = "${RETRY_INTERVALS:-5m,15m,1h,24h}"
+  retriesPerInterval = "${RETRY_INTERVALS_NUMBERS:-3,3,23}"
+  maxRetries = "${RETRY_OUT_MAX_TIMES:-32}"
 }
 
-
 messageResendPolicy {
-    startupDelay = "${SCHEDULED_PROCESS_STARTDELAY:-5m}"
-    processInterval = "${RESEND_PROCESS_INTERVAL:-1h}"
-    resendInterval = "${RESEND_INTERVAL:-12h}"
-    maxResends = "${RESEND_MAX_TIMES:-4}"
+  startupDelay = "${SCHEDULED_PROCESS_STARTDELAY:-5m}"
+  processInterval = "${RESEND_PROCESS_INTERVAL:-1h}"
+  resendInterval = "${RESEND_INTERVAL:-12h}"
+  maxResends = "${RESEND_MAX_TIMES:-4}"
+}
+
+cleanupPayloadsJob {
+  enabled = "${CLEANUP_PAYLOADS_ENABLED:-false}"
+  fixedInterval = "${CLEANUP_PAYLOADS_INTERVAL:-1d}"
+  startAtTime = "${CLEANUP_PAYLOADS_START_AT_TIME:-00:00}"
+  keepPayloadsDays = "${CLEANUP_PAYLOADS_KEEP_DAYS:-90}"
+  batchSize = "${CLEANUP_PAYLOADS_BATCH_SIZE:-10000}"
 }

--- a/ebms-async/src/main/resources/db/migration/V12__index_payload_created_at.sql
+++ b/ebms-async/src/main/resources/db/migration/V12__index_payload_created_at.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS idx_payload_created_at ON payload (created_at);

--- a/ebms-async/src/main/resources/db/migration/V13__define_delete_old_payloads_procedure.sql
+++ b/ebms-async/src/main/resources/db/migration/V13__define_delete_old_payloads_procedure.sql
@@ -1,0 +1,47 @@
+CREATE OR REPLACE PROCEDURE delete_old_payloads(
+    p_keep_days                 IN  int,    -- Angir hvor lenge payloads skal beholdes i databasen (slett de som er eldre).
+    p_batch_size                IN  int,    -- Hvor mange payloads som skal slettes om gangen.
+    o_total_deleted_payloads    OUT BIGINT  -- Returnerer antall slettede rader.
+)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_deleted_count int;
+    v_total_deleted_payloads BIGINT := 0;
+    v_delete_threshold_date TIMESTAMP := NOW() - (p_keep_days || ' day')::INTERVAL;
+BEGIN
+    RAISE NOTICE 'delete_old_payloads: Started';
+    LOOP
+        DELETE FROM payload
+        WHERE EXISTS (
+            SELECT 1
+            FROM (
+                 SELECT reference_id, content_id
+                 FROM payload
+                 WHERE created_at < v_delete_threshold_date
+                 ORDER BY created_at
+                 LIMIT p_batch_size
+             ) AS old_payloads
+            WHERE old_payloads.reference_id = payload.reference_id
+            AND old_payloads.content_id = payload.content_id
+        );
+
+        GET DIAGNOSTICS v_deleted_count = ROW_COUNT;
+        -- Avslutt loop hvis ingen flere rader igjen:
+        IF v_deleted_count = 0 THEN
+            RAISE NOTICE 'delete_old_payloads: No more entries left to delete - exiting the loop';
+            EXIT;
+        END IF;
+        RAISE NOTICE 'delete_old_payloads: Deleted % rows from the payload table.', v_deleted_count;
+        v_total_deleted_payloads := v_total_deleted_payloads + v_deleted_count;
+
+        COMMIT;
+        RAISE NOTICE 'delete_old_payloads: PERFORM pg_sleep(0.01)';
+        PERFORM pg_sleep(0.01); -- Small pause to reduce lock contention
+
+    END LOOP;
+
+    RAISE NOTICE 'delete_old_payloads: COMPLETE - deleted % payloads', v_total_deleted_payloads;
+    o_total_deleted_payloads := v_total_deleted_payloads;
+END;
+$$;

--- a/ebms-async/src/test/kotlin/no/nav/emottak/ebms/async/persistence/PayloadRepositoryTest.kt
+++ b/ebms-async/src/test/kotlin/no/nav/emottak/ebms/async/persistence/PayloadRepositoryTest.kt
@@ -2,8 +2,15 @@ package no.nav.emottak.ebms.async.persistence
 
 import no.nav.emottak.ebms.async.ebmsPostgres
 import no.nav.emottak.ebms.async.persistence.repository.PayloadRepository
+import no.nav.emottak.ebms.async.persistence.table.PayloadTable
+import no.nav.emottak.ebms.async.persistence.table.PayloadTable.contentId
+import no.nav.emottak.ebms.async.persistence.table.PayloadTable.referenceId
 import no.nav.emottak.ebms.async.testConfiguration
 import no.nav.emottak.message.model.AsyncPayload
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.update
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions
@@ -11,7 +18,10 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.testcontainers.containers.PostgreSQLContainer
 import java.sql.DriverManager
+import java.time.Instant
+import java.time.temporal.ChronoUnit
 import kotlin.uuid.Uuid
+import kotlin.uuid.toJavaUuid
 
 class PayloadRepositoryTest {
     companion object {
@@ -104,4 +114,66 @@ class PayloadRepositoryTest {
         Assertions.assertEquals(2, retrievedPayloads.size)
         Assertions.assertEquals(originalReferenceId, retrievedPayloads[0].referenceId)
     }
+
+    @Test
+    fun `cleanupOldPayloads should delete old payloads`() {
+        val insertPayloads = 5L
+        for (i in 1..insertPayloads) {
+            val payload = AsyncPayload(
+                referenceId = Uuid.random(),
+                contentId = "contentId$i",
+                contentType = "application/pkcs7-mime",
+                content = "Payload test content $i".toByteArray()
+            )
+            payloadRepository.updateOrInsert(payload)
+            val affectedRows = ebmsProviderDb.backdatePayload(payload, 6)
+            Assertions.assertEquals(1, affectedRows)
+        }
+        val rowsDeleted = payloadRepository.cleanupOldPayloads(keepDays = 5, batchSize = 3)
+        Assertions.assertEquals(insertPayloads, rowsDeleted)
+    }
+
+    @Test
+    fun `cleanupOldPayloads should not delete payloads newer than keepDays`() {
+        val insertPayloads = 5L
+        val referenceId = Uuid.random()
+        for (i in 1..insertPayloads) {
+            val payload = AsyncPayload(
+                referenceId = referenceId,
+                contentId = "contentId$i",
+                contentType = "application/pkcs7-mime",
+                content = "Payload test content $i".toByteArray()
+            )
+            payloadRepository.updateOrInsert(payload)
+            ebmsProviderDb.backdatePayload(payload, 6)
+        }
+        val contentId = "newContentId"
+        val payload = AsyncPayload(
+            referenceId = referenceId,
+            contentId = contentId,
+            contentType = "application/pkcs7-mime",
+            content = "Payload test new content".toByteArray()
+        )
+        payloadRepository.updateOrInsert(payload)
+        val rowsDeleted = payloadRepository.cleanupOldPayloads(keepDays = 5, batchSize = 3)
+        Assertions.assertEquals(insertPayloads, rowsDeleted)
+        val retrievedPayloads = payloadRepository.getByReferenceId(referenceId)
+        Assertions.assertNotNull(retrievedPayloads)
+        Assertions.assertEquals(1, retrievedPayloads.size)
+        Assertions.assertEquals(referenceId, retrievedPayloads[0].referenceId)
+        Assertions.assertEquals(contentId, retrievedPayloads[0].contentId)
+    }
 }
+
+/**
+ * Test helper for backdating the created_at column of payloads, bypassing the DEFAULT now()
+ * so cleanup logic can be exercised without waiting for real time to pass.
+ */
+fun Database.backdatePayload(payload: AsyncPayload, days: Long) =
+    transaction(db) {
+        PayloadTable.update(where = {
+            referenceId.eq(payload.referenceId.toJavaUuid()) and contentId.eq(payload.contentId)
+        }) {
+            it[contentAt] = Instant.now().minus(days, ChronoUnit.DAYS)
+        }
+    }


### PR DESCRIPTION
Laget en ny planlagt oppgave:
- `launchCleanupPayloadsTask()` - kjøres én gang om dagen ved midnatt (konfigurerbart).
- Payloads eldre enn 90 dager slettes (konfigurerbart).
- Sletting skjer batchvis ved 10000 rader om gangen (konfigurerbart).

Er en del av følgende oppgave: https://github.com/navikt/team-emottak-docs/issues/368